### PR TITLE
Add basic README file from kotct.emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Dot is a collective configuration system which contains configurations for progr
 Dot is written under the following principles:
 
 * Configurations should only be run if necessary&mdash;that is, if the *user* wants it.
-* Configurations should be as lean and modular as possible, utilizing autoload and byte compilation mechanisms whenever possible.
-* Configurations should be clean, well-documented, and consistently written throughout.
-* Configurations should have a focus on excellent support for everything.
+* Configurations should be as lean, modular, and standalone as possible, utilizing autoload and byte compilation mechanisms whenever possible and only running what is necessary.
+* Configurations should be clean, well-documented, and consistently-written throughout.
+* Configurations should have a focus on truly excellent support for everything.
 * Configurations should also have clear error messages handling common PEBKAC errors.
 
 ## Emacs

--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Dot is written under the following principles:
 * Configurations should be clean, well-documented, and consistently written throughout.
 * Configurations should have a focus on excellent support for everything.
 * Configurations should also have clear error messages handling common PEBKAC errors.
+
+## Emacs
+
+The Emacs configuration is the primary focus of this project and is the defining feature of this project.
+Most of the work done here will be done on the Emacs configuration, as the primary goal in writing this configuration is and was to write a robust, fast, and efficient Emacs configuration.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,36 @@
 # kotct/dot
 
-Dot is a collective configuration system which contains configurations for programs like Emacs and zsh, but also (potentially) Vim.
-Dot is written under the following principles:
+Dot is a collective configuration system which contains configurations
+for programs like Emacs and zsh, but also (potentially) Vim.  Dot is
+written under the following principles:
 
-* Configurations should only be run if necessary&mdash;that is, if the *user* wants it.
-* Configurations should be as lean, modular, and standalone as possible, utilizing autoload and byte compilation mechanisms whenever possible and only running what is necessary.
-* Configurations should be clean, well-documented, and consistently-written throughout.
-* Configurations should have a focus on truly excellent support for everything.
-* Configurations should also have clear error messages handling common PEBKAC errors.
+* Configurations should only be run if necessary&mdash;that is, if the
+  *user* wants it.
+* Configurations should be as lean, modular, and standalone as
+  possible, utilizing autoload and byte compilation mechanisms
+  whenever possible and only running what is necessary.
+* Configurations should be clean, well-documented, and
+  consistently-written throughout.
+* Configurations should have a focus on truly excellent support for
+  everything.
+* Configurations should also have clear error messages handling common
+  PEBKAC errors.
 
 ## Emacs
 
-The Emacs configuration is the primary focus of this project and is the defining feature of this project.
-Most of the work done here will be done on the Emacs configuration, as the primary goal in writing this configuration is and was to write a robust, fast, and efficient Emacs configuration.
+The Emacs configuration is the primary focus of this project and is
+the defining feature of this project.  Most of the work done here will
+be done on the Emacs configuration, as the primary goal in writing
+this configuration is and was to write a robust, fast, and efficient
+Emacs configuration.
 
-Below is included the discussion about the rewrite of the Emacs configuration, which will take place in this repository.
+Below is included the discussion about the rewrite of the Emacs
+configuration, which will take place in this repository.
 
 ### Goals
 
-Create a fast emacs config with a clean, unified style, that has IDE-level support for many languages.
+Create a fast emacs config with a clean, unified style, that has
+IDE-level support for many languages.
 
 - Autoload as much as possible.
 - Automatically byte-compile on start as much as possible.
@@ -32,22 +44,24 @@ Create a fast emacs config with a clean, unified style, that has IDE-level suppo
 Currently the rewrite is stored in the `new.emacs.d` directory.
 Symlink this to `~/.emacs.d` to use the config.
 
-Within the base `.emacs.d` directory, the only checked-in file is `init.el`.
-This file contains any code that must be loaded before the elisp hubs and
-any code that manages loading, autoloading, or byte compilation.
+Within the base `.emacs.d` directory, the only checked-in file is
+`init.el`.  This file contains any code that must be loaded before the
+elisp hubs and any code that manages loading, autoloading, or byte
+compilation.
 
-All other codes is organized into directories based on language.
-For instance, all emacs lisp code goes into the `lisp` directory, and ruby
-or python code goes into the `ruby` and `python` directories, respectively.
+All other codes is organized into directories based on language.  For
+instance, all emacs lisp code goes into the `lisp` directory, and ruby
+or python code goes into the `ruby` and `python` directories,
+respectively.
 
-The `lisp` directory contains a directory for each "hub".
-Within each hub directory is a `<hub-name>-hub.el` directory containing
-the hub definition (using the `kotct/hub` function).
-Each file within the hub that is loaded at startup should provide a
-feature with a simple name (e.g. "startup", "backup", or "recentf-c").
-If the file is configuring another package, name it `<package>-c`
-(as in "recentf-c" above), with "c" standing for "configuration."
-Try to avoid this "-c" suffix when possible.
+The `lisp` directory contains a directory for each "hub".  Within each
+hub directory is a `<hub-name>-hub.el` directory containing the hub
+definition (using the `kotct/hub` function).  Each file within the hub
+that is loaded at startup should provide a feature with a simple name
+(e.g. "startup", "backup", or "recentf-c").  If the file is
+configuring another package, name it `<package>-c` (as in "recentf-c"
+above), with "c" standing for "configuration."  Try to avoid this "-c"
+suffix when possible.
 
 ### Autoloading
 
@@ -57,6 +71,7 @@ Autoloaded files should contain at least one function or other symbol
 whose definition is preceded by an autoload token (`;;;###autoload`).
 
 At the top of the file, include the following comment:
+
 ```
 ;;; THIS FILE IS NOT LOADED AT STARTUP.
 ;;; This file is autoloaded on the following symbols:
@@ -72,16 +87,16 @@ Calls to `autoload` will be automatically generated and saved in
 
 #### Preserving package autoloads
 
-Generally, calls to `require` should be avoided, since these calls will
-sometimes force loading of features that would otherwise be autoloaded.
-Cases can occur in which a `require` is appropriate, for instance, if
-the package does not have autoloads or an autoload will be triggered
-later in the file anyway.
+Generally, calls to `require` should be avoided, since these calls
+will sometimes force loading of features that would otherwise be
+autoloaded.  Cases can occur in which a `require` is appropriate, for
+instance, if the package does not have autoloads or an autoload will
+be triggered later in the file anyway.
 
-If an autoloaded package needs configuration, instead of using `require`
-to load the package in order to configure it, wrap the configuration in
-a `with-eval-after-load` block so that it will only be loaded after the
-package is autoloaded.
+If an autoloaded package needs configuration, instead of using
+`require` to load the package in order to configure it, wrap the
+configuration in a `with-eval-after-load` block so that it will only
+be loaded after the package is autoloaded.
 
 ### Byte compilation
 
@@ -89,26 +104,29 @@ Still in progress.
 
 ### Keybindings
 
-Keybindings should be located at whatever places makes sense.
-Most commonly, they will be located after the definition of the
-function they are binding, or after relevant configuration.
+Keybindings should be located at whatever places makes sense.  Most
+commonly, they will be located after the definition of the function
+they are binding, or after relevant configuration.
 
 To globally bind a key, use a line such as:
+
 ```
 (global-set-key (kbd "C-x C-r") #'kotct/ido-recentf-open)
 ```
 
-At the top of any file with keybindings, add a comment like the following for each keybinding:
+At the top of any file with keybindings, add a comment like the
+following for each keybinding:
+
 ```
 ;;; C-x C-r: find recent files and directories using recentf
 ```
 
 ### Portability
 
-The only assumptions we can make about our environment are that we
-are using a certain minimum version of emacs (tbd) and we have all
-package dependencies installed (although we should handle the case at
-startup where not all dependencies are installed).
+The only assumptions we can make about our environment are that we are
+using a certain minimum version of emacs (tbd) and we have all package
+dependencies installed (although we should handle the case at startup
+where not all dependencies are installed).
 
 Things we CANNOT assume:
 - We are using a POSIX-compliant OS.
@@ -116,20 +134,22 @@ Things we CANNOT assume:
 - The user is not an idiot.
 
 Up for debate:
-- Can we assume we are not running from a terminal (i.e. can we design so that
-some functionality may not be present when running from a terminal)?
+- Can we assume we are not running from a terminal (i.e. can we design
+  so that some functionality may not be present when running from a
+  terminal)?
 
 ### Emacs lisp style guide
 
-- Prefix all global function or variable names with `kotct/`,
-as in `kotct/ido-recentf-open` or `kotct/hub-names`.
-- Always use `setf` instead of `setq`.
-`setq` should never be used in this project.
+- Prefix all global function or variable names with `kotct/`, as in
+  `kotct/ido-recentf-open` or `kotct/hub-names`.
+- Always use `setf` instead of `setq`.  `setq` should never be used in
+  this project.
 - When referencing a function name, always use a function quote (`#'`)
-instead of a regular quote (`'`). This function quote (or funquote) translates
-to a call to `function` instead of `quote`.
-- As described in the Autoloading section, avoid `require` and use `with-eval-after-load`.
-- Make sure all `defun`s, `defvar`s, and `defmacro`s (and any other global definitions)
-have docstrings that are properly formatted.
+  instead of a regular quote (`'`). This function quote (or funquote)
+  translates to a call to `function` instead of `quote`.
+- As described in the Autoloading section, avoid `require` and use
+  `with-eval-after-load`.
+- Make sure all `defun`s, `defvar`s, and `defmacro`s (and any other
+  global definitions) have docstrings that are properly formatted.
 - Comment when it's not immediately clear what the code is doing.
 - Write modular, clean, and fast code.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# kotct/dot
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # kotct/dot
 
+Dot is a collective configuration system which contains configurations for programs like Emacs and zsh, but also (potentially) Vim.
+Dot is written under the following principles:
+
+* Configurations should only be run if necessary&mdash;that is, if the *user* wants it.
+* Configurations should be as lean and modular as possible, utilizing autoload and byte compilation mechanisms whenever possible.
+* Configurations should be clean, well-documented, and consistently written throughout.
+* Configurations should have a focus on excellent support for everything.
+* Configurations should also have clear error messages handling common PEBKAC errors.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,123 @@ Dot is written under the following principles:
 
 The Emacs configuration is the primary focus of this project and is the defining feature of this project.
 Most of the work done here will be done on the Emacs configuration, as the primary goal in writing this configuration is and was to write a robust, fast, and efficient Emacs configuration.
+
+Below is included the discussion about the rewrite of the Emacs configuration, which will take place in this repository.
+
+### Goals
+
+Create a fast emacs config with a clean, unified style, that has IDE-level support for many languages.
+
+- Autoload as much as possible.
+- Automatically byte-compile on start as much as possible.
+- Use a clean, consistent emacs lisp style.
+- Have a focus on excellent support for individual languages.
+- Make sure everything is well-thought-out and well-documented.
+- Have clear error messages handling most user fuckups.
+
+### Structure
+
+Currently the rewrite is stored in the `new.emacs.d` directory.
+Symlink this to `~/.emacs.d` to use the config.
+
+Within the base `.emacs.d` directory, the only checked-in file is `init.el`.
+This file contains any code that must be loaded before the elisp hubs and
+any code that manages loading, autoloading, or byte compilation.
+
+All other codes is organized into directories based on language.
+For instance, all emacs lisp code goes into the `lisp` directory, and ruby
+or python code goes into the `ruby` and `python` directories, respectively.
+
+The `lisp` directory contains a directory for each "hub".
+Within each hub directory is a `<hub-name>-hub.el` directory containing
+the hub definition (using the `kotct/hub` function).
+Each file within the hub that is loaded at startup should provide a
+feature with a simple name (e.g. "startup", "backup", or "recentf-c").
+If the file is configuring another package, name it `<package>-c`
+(as in "recentf-c" above), with "c" standing for "configuration."
+Try to avoid this "-c" suffix when possible.
+
+### Autoloading
+
+#### Autoloading custom features
+
+Autoloaded files should contain at least one function or other symbol
+whose definition is preceded by an autoload token (`;;;###autoload`).
+
+At the top of the file, include the following comment:
+```
+;;; THIS FILE IS NOT LOADED AT STARTUP.
+;;; This file is autoloaded on the following symbols:
+;;;  kotct/function1
+;;;  kotct/function2
+```
+
+To make sure the file is checked for autoloads, ensure that in the
+hub file's call to `kotct/hub`, the final argument is `'autoloads`.
+
+Calls to `autoload` will be automatically generated and saved in
+`lisp/kotct-loaddefs.el` and loaded on startup.
+
+#### Preserving package autoloads
+
+Generally, calls to `require` should be avoided, since these calls will
+sometimes force loading of features that would otherwise be autoloaded.
+Cases can occur in which a `require` is appropriate, for instance, if
+the package does not have autoloads or an autoload will be triggered
+later in the file anyway.
+
+If an autoloaded package needs configuration, instead of using `require`
+to load the package in order to configure it, wrap the configuration in
+a `with-eval-after-load` block so that it will only be loaded after the
+package is autoloaded.
+
+### Byte compilation
+
+Still in progress.
+
+### Keybindings
+
+Keybindings should be located at whatever places makes sense.
+Most commonly, they will be located after the definition of the
+function they are binding, or after relevant configuration.
+
+To globally bind a key, use a line such as:
+```
+(global-set-key (kbd "C-x C-r") #'kotct/ido-recentf-open)
+```
+
+At the top of any file with keybindings, add a comment like the following for each keybinding:
+```
+;;; C-x C-r: find recent files and directories using recentf
+```
+
+### Portability
+
+The only assumptions we can make about our environment are that we
+are using a certain minimum version of emacs (tbd) and we have all
+package dependencies installed (although we should handle the case at
+startup where not all dependencies are installed).
+
+Things we CANNOT assume:
+- We are using a POSIX-compliant OS.
+- We have external dependencies installed (such as Ruby or Python).
+- The user is not an idiot.
+
+Up for debate:
+- Can we assume we are not running from a terminal (i.e. can we design so that
+some functionality may not be present when running from a terminal)?
+
+### Emacs lisp style guide
+
+- Prefix all global function or variable names with `kotct/`,
+as in `kotct/ido-recentf-open` or `kotct/hub-names`.
+- Always use `setf` instead of `setq`.
+`setq` should never be used in this project.
+- When referencing a function name, always use a function quote (`#'`)
+instead of a regular quote (`'`). This function quote (or funquote) translates
+to a call to `function` instead of `quote`.
+- As described in the Autoloading section, avoid `require` and use `with-eval-after-load`.
+- Make sure all `defun`s, `defvar`s, and `defmacro`s (and any other global definitions)
+have docstrings that are properly formatted.
+- Comment when it's not immediately clear what the code is doing.
+- Write modular, clean, and fast code.


### PR DESCRIPTION
As this is the central repository for the rewrite of kotct.emacs and the introduction of further work on a modular zsh configuration and such, we should really add the README to the `master` branch so that the master branch doesn't contain something that is blank.  In addition, further work on the README can just be done on a branch and be pull-requested.
