### PR TITLE
Add automated tab system

### DIFF
--- a/.emacs.d/lisp/code/code-hub.el
+++ b/.emacs.d/lisp/code/code-hub.el
@@ -1,9 +1,10 @@
-(add-to-list 'load-path (concat (file-name-directory load-file-name) "languages/"))
-
 (kotct/hub "code"
            (magit-c
             indentation
-            code-navigation
-            language-hub))
+            code-navigation))
+
+;;; load individual language files via language-hub
+(add-to-list 'load-path (concat (file-name-directory load-file-name) "languages/"))
+(require 'language-hub)
 
 (provide 'code-hub)

--- a/.emacs.d/lisp/code/indentation.el
+++ b/.emacs.d/lisp/code/indentation.el
@@ -4,31 +4,34 @@
 
 ;; define automated tab-setting system
 (defvar kotct/tab-variable-setters
-  '((global-tab-width . #'set))
+  '((global-tab-width . setf))
   "An alist of symbols representing variables and the method
 used to set them to the tab width 
-(almost always either #'set or #'set-default).")
+(almost always either setf or setq-default).")
 
 (defmacro kotct/setf-tab (var)
   "Set the variable VAR to the tab width and keep it updated
 if the tab width changes."
   `(progn
-     (setf var global-tab-width)
-     (setf kotct/tab-variable-setters (acons var #'set kotct/tab-variable-setters))))
+     (setf ,var global-tab-width)
+     (setf kotct/tab-variable-setters (cons  '(,var . setf) kotct/tab-variable-setters))))
 
 (defmacro kotct/setq-default-tab (var)
   "Set default value of the variable VAR to the tab width 
 and keep it updated if the tab width changes."
   `(progn
-     (setq-default var global-tab-width)
-     (setf kotct/tab-variable-setters (acons var #'set-default kotct/tab-variable-setters))))
+     (setq-default ,var global-tab-width)
+     (setf kotct/tab-variable-setters (cons '(,var . setq-default) kotct/tab-variable-setters))))
 
-(defun kotct/set-tab-width (width)
-  (dolist (pair)
-    (apply (cdr pair) (car pair) (list width))))
+(defmacro kotct/set-tab-width (width)
+  "Set `global-tab-width' and all other associated tab width
+variables in `kotct/tab-variable-setters' to WIDTH."
+  (cons 'progn
+        (mapcar (lambda (pair) (list (cdr pair) (car pair) width))
+                kotct/tab-variable-setters)))
 
-(setq-default-tab tab-width global-tab-width)
-(setf-tab smie-indent-basic global-tab-width)
+(kotct/setq-default-tab tab-width)
+(kotct/setf-tab smie-indent-basic)
 
 ;; by default, don't use tabs
 (setq-default indent-tabs-mode nil)

--- a/.emacs.d/lisp/code/indentation.el
+++ b/.emacs.d/lisp/code/indentation.el
@@ -1,8 +1,39 @@
+;; set the default tab width to 4 chars
+;; this is the reference variable for the tab width
 (setf global-tab-width 4)
-(setq-default tab-width global-tab-width)
-(setf smie-indent-basic global-tab-width)
 
+;; define automated tab-setting system
+(defvar kotct/tab-variable-setters
+  '((global-tab-width . #'set))
+  "An alist of symbols representing variables and the method
+used to set them to the tab width 
+(almost always either #'set or #'set-default).")
+
+(defmacro kotct/setf-tab (var)
+  "Set the variable VAR to the tab width and keep it updated
+if the tab width changes."
+  `(progn
+     (setf var global-tab-width)
+     (setf kotct/tab-variable-setters (acons var #'set kotct/tab-variable-setters))))
+
+(defmacro kotct/setq-default-tab (var)
+  "Set default value of the variable VAR to the tab width 
+and keep it updated if the tab width changes."
+  `(progn
+     (setq-default var global-tab-width)
+     (setf kotct/tab-variable-setters (acons var #'set-default kotct/tab-variable-setters))))
+
+(defun kotct/set-tab-width (width)
+  (dolist (pair)
+    (apply (cdr pair) (car pair) (list width))))
+
+(setq-default-tab tab-width global-tab-width)
+(setf-tab smie-indent-basic global-tab-width)
+
+;; by default, don't use tabs
 (setq-default indent-tabs-mode nil)
+
+;; when you hit DEL on a tab, delete the whole tab, don't convert to spaces
 (setf backward-delete-char-untabify-method nil)
 
 (provide 'indentation)

--- a/.emacs.d/lisp/code/languages/c.el
+++ b/.emacs.d/lisp/code/languages/c.el
@@ -1,8 +1,10 @@
+(require 'indentation)
+
 ;; set style to linux
 (setf c-default-style "linux")
 
 ;; use tab-width for indentation
-(setf-tab c-basic-offset)
+(kotct/setf-tab c-basic-offset)
 
 ;; use smart tabs
 (smart-tabs-insinuate 'c)

--- a/.emacs.d/lisp/code/languages/c.el
+++ b/.emacs.d/lisp/code/languages/c.el
@@ -2,7 +2,7 @@
 (setf c-default-style "linux")
 
 ;; use tab-width for indentation
-(setf c-basic-offset tab-width)
+(setf-tab c-basic-offset)
 
 ;; use smart tabs
 (smart-tabs-insinuate 'c)

--- a/.emacs.d/lisp/code/languages/ruby.el
+++ b/.emacs.d/lisp/code/languages/ruby.el
@@ -1,5 +1,7 @@
+(require 'indentation)
+
 ;; Set ruby-indent-level to global-tab-width
-(setq-default-tab ruby-indent-level)
+(kotct/setq-default-tab ruby-indent-level)
 
 ;; Add Smart Tabs language support for Ruby using the
 ;; `smart-tabs-add-language-support' macro.

--- a/.emacs.d/lisp/code/languages/ruby.el
+++ b/.emacs.d/lisp/code/languages/ruby.el
@@ -1,5 +1,5 @@
 ;; Set ruby-indent-level to global-tab-width
-(setq-default ruby-indent-level global-tab-width)
+(setq-default-tab ruby-indent-level)
 
 ;; Add Smart Tabs language support for Ruby using the
 ;; `smart-tabs-add-language-support' macro.


### PR DESCRIPTION
Instead of `(setf var global-tab-width)`, do `(kotct/setf-tab var)`.

Instead of `(setq-default var global-tab-width)`, do `(kotct/setq-default-tab var)`.

Update the tab width with `kotct/set-tab-width`.

Is this kinda what you had in mind, @rye?