### PR TITLE
EditorConfig

### DIFF
--- a/.emacs.d/lisp/behavior/text.el
+++ b/.emacs.d/lisp/behavior/text.el
@@ -16,7 +16,9 @@
 (defvar kotct/sexp-copy-count
   0
   "Number of commands since last `kotct/sexp-copy-as-kill'.")
+
 (add-hook 'pre-command-hook (lambda () (incf kotct/sexp-copy-count)))
+
 (defun kotct/sexp-copy-as-kill (arg)
   "Save next sexp as if killed, but don't kill it, appending if called repeatedly."
   (interactive "p")
@@ -28,6 +30,7 @@
         (append-next-kill))
     (clipboard-kill-ring-save beg (point))
     (setq kotct/sexp-copy-count 0)))
+
 (global-set-key (kbd "C-M-w") #'kotct/sexp-copy-as-kill)
 
 (provide 'text)

--- a/.emacs.d/lisp/code/code-hub.el
+++ b/.emacs.d/lisp/code/code-hub.el
@@ -1,7 +1,8 @@
 (add-to-list 'load-path (concat (file-name-directory load-file-name) "languages/"))
 
 (kotct/hub "code"
-           (magit-c
+           (editorconfig-c
+            magit-c
             indentation
             language-hub))
 

--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -1,1 +1,4 @@
+;; Enable EditorConfig mode
+(editorconfig-mode +1)
+
 (provide 'editorconfig-c)

--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -9,4 +9,19 @@
 
 (add-hook 'editorconfig-custom-hooks 'kotct/editorconfig--disable-smart-tabs-if-indent-tabs-mode-disabled)
 
+(defvar kotct/editorconfig--suppress-core-not-found-warning
+  nil
+  "If non-nil, warning on startup is suppressed.")
+
+(defun kotct/editorconfig-check-for-core (&optional suppress)
+  "Checks if EditorConfig C core is installed.
+
+Debug warning is suppressed if SUPPRESS is non-nil."
+
+  (if (not suppress)
+      (if (not (executable-find editorconfig-exec-path))
+          (lwarn '(editorconfig core) :debug "EditorConfig executable not found."))))
+
+(kotct/editorconfig-check-for-core kotct/editorconfig--suppress-core-not-found-warning)
+
 (provide 'editorconfig-c)

--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -1,4 +1,12 @@
 ;; Enable EditorConfig mode
 (editorconfig-mode +1)
 
+(defun kotct/editorconfig--disable-smart-tabs-if-indent-tabs-mode-disabled (&optional hash)
+  "Disables `smart-tabs-mode' if `indent-tabs-mode' is non-truthy."
+  (if (not indent-tabs-mode)
+      (progn
+        (smart-tabs-mode -1))))
+
+(add-hook 'editorconfig-custom-hooks 'kotct/editorconfig--disable-smart-tabs-if-indent-tabs-mode-disabled)
+
 (provide 'editorconfig-c)

--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -1,8 +1,11 @@
 ;; Enable EditorConfig mode
 (editorconfig-mode +1)
 
-(defun kotct/editorconfig--disable-smart-tabs-if-indent-tabs-mode-disabled (&optional hash)
-  "Disables `smart-tabs-mode' if `indent-tabs-mode' is non-truthy."
+(defun kotct/editorconfig-disable-smart-tabs-if-indent-tabs-mode-disabled (&optional hash)
+  "Disables `smart-tabs-mode' if `indent-tabs-mode' is non-truthy.
+
+HASH is passed in when `editorconfig-custom-hooks' is evaluated,
+and is ignored."
   (if (not indent-tabs-mode)
       (progn
         (smart-tabs-mode -1))))

--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -1,0 +1,1 @@
+(provide 'editorconfig-c)

--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -10,9 +10,9 @@ and is ignored."
       (progn
         (smart-tabs-mode -1))))
 
-(add-hook 'editorconfig-custom-hooks 'kotct/editorconfig--disable-smart-tabs-if-indent-tabs-mode-disabled)
+(add-hook 'editorconfig-custom-hooks 'kotct/editorconfig-disable-smart-tabs-if-indent-tabs-mode-disabled)
 
-(defvar kotct/editorconfig--suppress-core-not-found-warning
+(defvar kotct/editorconfig-suppress-core-not-found-warning
   nil
   "If non-nil, warning on startup is suppressed.")
 
@@ -25,6 +25,6 @@ Debug warning is suppressed if SUPPRESS is non-nil."
       (if (not (executable-find editorconfig-exec-path))
           (lwarn '(editorconfig core) :debug "EditorConfig executable not found."))))
 
-(kotct/editorconfig-check-for-core kotct/editorconfig--suppress-core-not-found-warning)
+(kotct/editorconfig-check-for-core kotct/editorconfig-suppress-core-not-found-warning)
 
 (provide 'editorconfig-c)

--- a/.emacs.d/lisp/package/dependencies.el
+++ b/.emacs.d/lisp/package/dependencies.el
@@ -13,6 +13,7 @@
     smart-tabs-mode ;; indentation with tabs and spaces
     ace-jump-mode ;; immediately jump to any visible character
     ace-jump-zap ;; zap-to-char but harnessing ace-jump
+    editorconfig ;; editorconfig plugin
 
     ;; THEMES
     solarized-theme)


### PR DESCRIPTION
This probably sucks and isn't exactly what we want, especially with the core warning, but it does implement basic support for `editorconfig-mode`.  I have tested it and it does effectively change indentation style.