### PR TITLE
Set the standard-indent variable

### DIFF
--- a/.emacs.d/lisp/code/indentation.el
+++ b/.emacs.d/lisp/code/indentation.el
@@ -33,6 +33,9 @@ variables in `kotct/tab-variable-setters' to WIDTH."
 (kotct/setq-default-tab tab-width)
 (kotct/setf-tab smie-indent-basic)
 
+;; Set the base indent variable.
+(kotct/setf-tab standard-indent)
+
 ;; by default, don't use tabs
 (setq-default indent-tabs-mode nil)
 


### PR DESCRIPTION
This is used in a lot of places to specify standard indentation.  Web-mode, for one, uses it to determine the standard indentation.