### PR TITLE
Kill loaddefs Buffer on Startup

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -10,7 +10,6 @@
 
 (setf generated-autoload-file "~/.emacs.d/lisp/kotct-loaddefs.el")
 
-
 ;;; hub initialization
 (defvar kotct/hub-list
   '("package"
@@ -52,6 +51,7 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
 
             (mapc #'require ,feature-var))))
 
+
 ;; add hub directories to load path
 (let ((default-directory "~/.emacs.d/lisp/"))
   (add-to-list 'load-path default-directory)
@@ -64,9 +64,9 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
           (require (intern (concat hub "-hub"))))
         kotct/hub-list))
 
+
 ;; load autoloads
 (require 'kotct-loaddefs)
-
 
 ;;; async byte compilation
 (let* ((to-eval `(let ((default-directory "~/.emacs.d/lisp/"))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -79,7 +79,8 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
   ;; start the process in *config-compilation* buffer
   (apply #'start-process args))
 
-
+;; Warn the user about shadowed files on the load path.  This usually
+;; happens when one keeps .elc files from removed .el files.
 (if (list-load-path-shadows)
     (message "There are shadowed files on your load path.
 This could indicate an issue with your emacs installation.
@@ -87,6 +88,8 @@ Despite this, your config appears to have loaded successfully.")
   (message "Your config appears to have loaded successfully. Rock on!"))
 
 
+;; Kill the buffer corresponding to `generated-autoload-file'.  After
+;; loading autoloads, we don't need it anymore.
 (let ((loaddefs-buffer (get-buffer (file-name-nondirectory generated-autoload-file))))
   (if loaddefs-buffer
       (kill-buffer loaddefs-buffer)))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -2,10 +2,7 @@
 
 ;;; autoload configuration
 
-;; Added by Package.el.  This must come before configurations of
-;; installed packages.  Don't delete this line.  If you don't want it,
-;; just comment it out by adding a semicolon to the start of the line.
-;; You may delete these explanatory comments.
+;; Initialize the package repository.
 (package-initialize)
 
 (setf generated-autoload-file "~/.emacs.d/lisp/kotct-loaddefs.el")

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -87,5 +87,10 @@ Despite this, your config appears to have loaded successfully.")
   (message "Your config appears to have loaded successfully. Rock on!"))
 
 
+(let ((loaddefs-buffer (get-buffer (file-name-nondirectory generated-autoload-file))))
+  (if loaddefs-buffer
+      (kill-buffer loaddefs-buffer)))
+
+
 ;;; custom-set-{variables,faces}
 (setf custom-file "~/.emacs.d/custom.el")

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -10,6 +10,7 @@
 
 (setf generated-autoload-file "~/.emacs.d/lisp/kotct-loaddefs.el")
 
+
 ;;; hub initialization
 (defvar kotct/hub-list
   '("package"
@@ -51,7 +52,6 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
 
             (mapc #'require ,feature-var))))
 
-
 ;; add hub directories to load path
 (let ((default-directory "~/.emacs.d/lisp/"))
   (add-to-list 'load-path default-directory)
@@ -64,9 +64,9 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
           (require (intern (concat hub "-hub"))))
         kotct/hub-list))
 
-
 ;; load autoloads
 (require 'kotct-loaddefs)
+
 
 ;;; async byte compilation
 (let* ((to-eval `(let ((default-directory "~/.emacs.d/lisp/"))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1,14 +1,13 @@
 ;;; dot/.emacs
 
-;;; autoload configuration
-
 ;; Initialize the package repository.
 (package-initialize)
 
+;;; Autoload Configuration
 (setf generated-autoload-file "~/.emacs.d/lisp/kotct-loaddefs.el")
 
 
-;;; hub initialization
+;;; Hub Initialization
 (defvar kotct/hub-list
   '("package"
     "file"
@@ -65,7 +64,7 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
 (require 'kotct-loaddefs)
 
 
-;;; async byte compilation
+;;; Asynchronous Byte Compilation
 (let* ((to-eval `(let ((default-directory "~/.emacs.d/lisp/"))
                    (package-initialize)
                    (add-to-list 'load-path default-directory)
@@ -84,7 +83,6 @@ This could indicate an issue with your emacs installation.
 Despite this, your config appears to have loaded successfully.")
   (message "Your config appears to have loaded successfully. Rock on!"))
 
-
 ;; Kill the buffer corresponding to `generated-autoload-file'.  After
 ;; loading autoloads, we don't need it anymore.
 (let ((loaddefs-buffer (get-buffer (file-name-nondirectory generated-autoload-file))))
@@ -92,5 +90,5 @@ Despite this, your config appears to have loaded successfully.")
       (kill-buffer loaddefs-buffer)))
 
 
-;;; custom-set-{variables,faces}
+;;; Customization File
 (setf custom-file "~/.emacs.d/custom.el")

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -82,7 +82,7 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
 
 (if (list-load-path-shadows)
     (message "There are shadowed files on your load path.
-This could indiciate an issue with your emacs installation.
+This could indicate an issue with your emacs installation.
 Despite this, your config appears to have loaded successfully.")
   (message "Your config appears to have loaded successfully. Rock on!"))
 

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -17,12 +17,13 @@
     "user")
   "A list of hubs to load at init.")
 
-;; populated by kotct/hub
+;; This variable is `nil' to begin with but gets populated by
+;; `kotct/hub' later on.
 (defvar kotct/files-to-compile
   nil
   "A list of files that ought to be byte-compiled.")
 
-;; used to define hubs in hub files
+;; Used by hubs to register themselves
 (defmacro kotct/hub (hubname features &optional autoloads)
   "Loads the hub denoted by HUBNAME.
 
@@ -48,19 +49,19 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
 
             (mapc #'require ,feature-var))))
 
-;; add hub directories to load path
+;; Add hub directories to the load paths.
 (let ((default-directory "~/.emacs.d/lisp/"))
   (add-to-list 'load-path default-directory)
   (normal-top-level-add-to-load-path kotct/hub-list))
 
-;; if byte-compiled files are out of date, load newer version
+;; If byte-compiled files are older, load newer version.
 (let ((load-prefer-newer t))
   ;; require all hubs
   (mapc (lambda (hub)
           (require (intern (concat hub "-hub"))))
         kotct/hub-list))
 
-;; load autoloads
+;; Load the loaddefs.
 (require 'kotct-loaddefs)
 
 
@@ -70,9 +71,9 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
                    (add-to-list 'load-path default-directory)
                    (normal-top-level-add-to-load-path ',kotct/hub-list)
                    (batch-byte-compile t)))
-       ;; command-line args as a list
+       ;; Command-line args as a list
        (args `("config-compilation" "*config-compilation*" "emacs" "--batch" "--eval" ,(format "%S" to-eval) ,@kotct/files-to-compile)))
-  ;; start the process in *config-compilation* buffer
+  ;; Start the process in *config-compilation* buffer
   (apply #'start-process args))
 
 ;; Warn the user about shadowed files on the load path.  This usually
@@ -91,4 +92,6 @@ Despite this, your config appears to have loaded successfully.")
 
 
 ;;; Customization File
+;; We set this to something we don't track because it can be unique
+;; for each system.
 (setf custom-file "~/.emacs.d/custom.el")


### PR DESCRIPTION
This is a fairly trivial change, to resolve #17.  We just try and find the loaddefs buffer, and if we find it, we close it.

As opposed to just killing by filename, this throws in error handling so we don't get stupid warning panes.