### PR TITLE
Always delete trailing whitespace before saving

### DIFF
--- a/.emacs.d/lisp/behavior/text.el
+++ b/.emacs.d/lisp/behavior/text.el
@@ -33,4 +33,7 @@
 
 (global-set-key (kbd "C-M-w") #'kotct/sexp-copy-as-kill)
 
+;; Always delete trailing whitespace before saving.
+(add-hook 'before-save-hook #'delete-trailing-whitespace)
+
 (provide 'text)


### PR DESCRIPTION
It's gross to have trailing whitespace.  In fact, most VC systems whine about it.  What's the point of having it?

We now just call `delete-trailing-whitespace` on `before-save-hook`.