### PR TITLE
Don't require Git from user/user-config-system

### DIFF
--- a/.emacs.d/lisp/user/user-config-system.el
+++ b/.emacs.d/lisp/user/user-config-system.el
@@ -1,7 +1,5 @@
 ;;; C-x C-z: switch personal configs
 
-(require 'git)
-
 (defvar kotct/user-current-username
   nil
   "The username associated with the currently loaded personal config.")


### PR DESCRIPTION
Since it was unused, there's no reason to load it.  The only other solution to #34 that I can think of is to make this `require` optional.

*Closes #34*.