### PR TITLE
Custom Font Rescaling System

### DIFF
--- a/.emacs.d/lisp/visual/text-visuals.el
+++ b/.emacs.d/lisp/visual/text-visuals.el
@@ -10,14 +10,14 @@
 ;; Minor mode which highlights TODO, FIXME, DONE, FAIL, etc.
 (add-hook 'prog-mode-hook 'hl-todo-mode)
 
+(defvar kotct/font-default-height
+  12.0
+  "The default font height.")
+
 ;; Sets the font name to NAME.
 (defun kotct/font-set-name (name)
   "Sets the `:font' face attribute on the `default' face to match NAME."
   (set-face-attribute 'default nil :font name))
-
-(defvar kotct/font-default-height
-  12.0
-  "The default font height.")
 
 ;; Sets the font height to what a user would expect their value to map to.
 ;;
@@ -29,8 +29,33 @@
   (interactive "nNew font height: ")
   (set-face-attribute 'default nil :height (floor (* 10.0 height))))
 
-;; Set the font height to the default height.
-(kotct/font-set-height kotct/font-default-height)
+(defvar kotct/font-rescale-factor
+  1.0
+  "The proportion that the font height change is multiplied by.")
+
+(defun kotct/font-rescale-height (amount)
+  "Sets the `:height' face attribute on the `default' face to
+`kotct/font-rescale-factor' * AMOUNT + the current height."
+  (let ((new-size (+ (* kotct/font-rescale-factor amount)
+                     (/ (face-attribute 'default :height) 10.0))))
+    (set-face-attribute 'default nil :height (floor (* 10.0 new-size)))))
+
+(defun kotct/font-upscale-height () (interactive "*") (kotct/font-rescale-height +1.0))
+(defun kotct/font-downscale-height () (interactive "*") (kotct/font-rescale-height -1.0))
+(defun kotct/font-reset-height () (interactive "*") (kotct/font-set-height kotct/font-default-height))
+
+(global-unset-key (kbd "C-x C-+"))
+(global-unset-key (kbd "C-x C-="))
+(global-unset-key (kbd "C-x C--"))
+(global-unset-key (kbd "C-x C-0"))
+
+(global-set-key (kbd "C-x C-+") #'kotct/font-upscale-height)
+(global-set-key (kbd "C-x C-=") #'kotct/font-upscale-height)
+(global-set-key (kbd "C-x C--") #'kotct/font-downscale-height)
+(global-set-key (kbd "C-x C-0") #'kotct/font-reset-height)
+
+;; Reset the font height to the default.
+(kotct/font-reset-height)
 
 ;; Any matching parenthesis is highlighted
 (show-paren-mode +1)

--- a/.emacs.d/lisp/visual/text-visuals.el
+++ b/.emacs.d/lisp/visual/text-visuals.el
@@ -1,3 +1,8 @@
+;;; (rebind) C-x C-+: increases font size by scaling `:height' frame parameter
+;;; (rebind) C-x C-=: increases font size by scaling `:height' frame parameter
+;;; (rebind) C-x C--: decreases font size by scaling `:height' frame parameter
+;;; (rebind) C-x C-0: resets font size to `kotct/font-default-height'
+
 ;; Minor mode to provide visual feedback for
 ;; some operations.
 (require 'volatile-highlights)
@@ -57,7 +62,7 @@
 ;; Reset the font height to the default.
 (kotct/font-reset-height)
 
-;; Any matching parenthesis is highlighted
+;; Any matching parenthesis is highlighted.
 (show-paren-mode +1)
 
 (provide 'text-visuals)


### PR DESCRIPTION
The default, built-in Emacs font re-scaling system [has](http://unix.stackexchange.com/q/7507/202251) [some](http://unix.stackexchange.com/q/29786/202251) [issues](https://github.com/syl20bnr/spacemacs/issues/1647).

This is a fix which is more of a re-implementation of the built-in Emacs font rescaling keybindings.  However, it adds functionality by allowing users to set a default font size (configured via `kotct/font-default-height`) and the factor by which they want to scale when they use the scaling system.

When scaling is applied via `C-x C-+`, `C-x C-=`, or `C-x C--`, the call to `kotct/font-rescale-height` is given either `+1` or `-1`. `kotct/font-rescale-factor` is then multiplied by this number to produce the change in height.

This works quite well for me.

[`rye-hub` currently contains](https://github.com/rye/.emacs/blob/67935cf788cf7938ba1e370c797df90d53685dec/rye-hub.el#L6-L7) an additional key-binding which makes this quite useful for jumping to a specific font size.

Yes, [a fix][linum-fix-using-builtin] does exist which uses the built-in rescaling system, but since it's much more complicated and this option provides more features and configuration for users to use, I think this is better.

[linum-fix-using-builtin]: http://unix.stackexchange.com/a/30087/202251

*This PR is held until review by @cg505.*