### PR TITLE
Don't fail horribly when we are missing packages and starting headless

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -57,7 +57,11 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
   (normal-top-level-add-to-load-path kotct/hub-list))
 
 (defun kotct/load-hubs (&optional frame)
-  ;; (if ignore (error "%s" (frame-terminal ignore)))
+  "Does the majority of initialization for dot/.emacs,
+by loading the hubs defined in `kotct/hub-list'.
+
+Pass FRAME if the function is being called on `after-make-frame-functions'
+and we need to remove the hook and specifically use the frame."
   ;; If byte-compiled files are older, load newer version.
   (let ((load-prefer-newer t))
     (when frame

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -56,15 +56,28 @@ If AUTOLOADS is non-nil, update the autoloads for that directory."
   (add-to-list 'load-path default-directory)
   (normal-top-level-add-to-load-path kotct/hub-list))
 
-;; If byte-compiled files are older, load newer version.
-(let ((load-prefer-newer t))
-  ;; require all hubs
-  (mapc (lambda (hub)
-          (require (intern (concat hub "-hub"))))
-        kotct/hub-list))
+(defun kotct/load-hubs (&optional frame)
+  ;; (if ignore (error "%s" (frame-terminal ignore)))
+  ;; If byte-compiled files are older, load newer version.
+  (let ((load-prefer-newer t))
+    (when frame
+      (select-frame frame)
+      ;; second run, we already have the resources to verify packages
+      (kotct/check-dependency-list frame)
+      (remove-hook 'after-make-frame-functions #'kotct/load-hubs))
+    ;; require all hubs
+    (mapc (lambda (hub)
+            (require (intern (concat hub "-hub"))))
+          kotct/hub-list)
+    ;; Load the loaddefs.
+    (require 'kotct-loaddefs)))
 
-;; Load the loaddefs.
-(require 'kotct-loaddefs)
+;; if we are running in daemon-mode and some packages aren't installed,
+;; wait until a frame is created to finish loading
+(if (eq 'daemon-mode
+        (catch 'daemon-mode
+          (kotct/load-hubs)))
+    (add-hook 'after-make-frame-functions #'kotct/load-hubs))
 
 
 ;;; Asynchronous Byte Compilation

--- a/.emacs.d/lisp/package/verification.el
+++ b/.emacs.d/lisp/package/verification.el
@@ -2,9 +2,15 @@
 
 ;; check to make sure all dependencies are installed before continuing
 (defun kotct/check-dependency-list (&optional frame)
-  ;; (if frame (error "%s" frame))
+  "Check to make sure all dependencies in `kotct/dependency-list' are installed.
+If not, interactively prompt the user to install them via `kotct/packup-install-dependencies'.
+
+FRAME is used to determine whether or not we are running headless
+(e.g., as a result of `emacs --daemon`). If we are, throw 'daemon-mode.
+It is the caller's responsibility to catch this and handle it properly.
+Typically this happens in init.el."
   (if (not (every #'package-installed-p kotct/dependency-list))
-      (if (string= (terminal-name (or frame (frame-terminal))) "initial_terminal")
+      (if (string= (terminal-name (frame-terminal frame)) "initial_terminal")
           (throw 'daemon-mode 'daemon-mode)
         (y-or-n-p "You don't seem to have all necessary packages installed. Install them?\n(Your emacs will probably not work if you don't.)")
         ;; since loaddefs don't get evaluated until after init, we must

--- a/.emacs.d/lisp/package/verification.el
+++ b/.emacs.d/lisp/package/verification.el
@@ -12,7 +12,7 @@ Typically this happens in init.el."
   (if (not (every #'package-installed-p kotct/dependency-list))
       (if (string= (terminal-name (frame-terminal frame)) "initial_terminal")
           (throw 'daemon-mode 'daemon-mode)
-        (y-or-n-p "You don't seem to have all necessary packages installed. Install them?\n(Your emacs will probably not work if you don't.)")
+        (y-or-n-p "You don't seem to have all necessary packages installed. Install them?\n(This configuration will probably not work if you don't.)")
         ;; since loaddefs don't get evaluated until after init, we must
         ;; manually require packup (normally loaded via autoloads)
         (require 'packup)

--- a/.emacs.d/lisp/package/verification.el
+++ b/.emacs.d/lisp/package/verification.el
@@ -1,15 +1,19 @@
 (require 'cl)
 
 ;; check to make sure all dependencies are installed before continuing
-(defun kotct/check-dependency-list ()
-    (if (not (every #'package-installed-p kotct/dependency-list))
-        (progn
-          (y-or-n-p "You don't seem to have all necessary packages installed. Install them?\n(Your emacs will probably not work if you don't.)")
-          ;; since loaddefs don't get evaluated until after init, we must
-          ;; manually require packup (normally loaded via autoloads)
-          (require 'packup)
-          (kotct/packup-install-dependencies nil))))
+(defun kotct/check-dependency-list (&optional frame)
+  ;; (if frame (error "%s" frame))
+  (if (not (every #'package-installed-p kotct/dependency-list))
+      (if (string= (terminal-name (or frame (frame-terminal))) "initial_terminal")
+          (throw 'daemon-mode 'daemon-mode)
+        (y-or-n-p "You don't seem to have all necessary packages installed. Install them?\n(Your emacs will probably not work if you don't.)")
+        ;; since loaddefs don't get evaluated until after init, we must
+        ;; manually require packup (normally loaded via autoloads)
+        (require 'packup)
+        (kotct/packup-install-dependencies nil))))
+
+;; provide before checking, so that if checking fails (i.e. we're in
+;; daemon mode) we know that we have the feature
+(provide 'verification)
 
 (kotct/check-dependency-list)
-
-(provide 'verification)

--- a/.emacs.d/lisp/user/user-config-system.el
+++ b/.emacs.d/lisp/user/user-config-system.el
@@ -55,10 +55,12 @@ If USERNAME is nil, prompt for a username."
         (with-temp-buffer
           (insert-file-contents filename)
           (replace-regexp-in-string "\n\\'" "" (buffer-string)))
-      (if (y-or-n-p "Would you like to set a default personal config?")
-          (kotct/user-write-default-username (kotct/user-ask-username "Choose default username: "))
-        ;; default to base-config, save so that we don't keep asking
-        (kotct/user-write-default-username "base-config")))))
+      (if (string= (terminal-name (frame-terminal frame)) "initial_terminal")
+          (throw 'daemon-mode 'daemon-mode)
+        (if (y-or-n-p "Would you like to set a default personal config?")
+            (kotct/user-write-default-username (kotct/user-ask-username "Choose default username: "))
+          ;; default to base-config, save so that we don't keep asking
+          (kotct/user-write-default-username "base-config"))))))
 
 (defun kotct/user-set-default-username (&optional username)
   "Set the default username to USERNAME, and switch to USERNAME's personal config.


### PR DESCRIPTION
My approach is what I initially suggested on #21: when we find out we're headless (i.e. `emacs --daemon`) and we don't have everything we need, halt startup and wait until we have an actual frame to continue. This is accomplished by implementing the additional function `kotct/load-hubs` and using throw-catch from `kotct/check-dependency-list` to `init.el`.

This fix works both for global dependencies and for user-specific dependencies.

I realized as I was typing this PR that I need to do a little bit of clean-up: one more commit is incoming.

*Closes #21*.