### PR TITLE
Add machine-local configuration option

### DIFF
--- a/.emacs.d/lisp/user/machine-local.el
+++ b/.emacs.d/lisp/user/machine-local.el
@@ -1,6 +1,6 @@
 (defun kotct/dot-config-directory ()
   "Returns the directory name for where our machine-local Dot configuration directory should be."
-  (concat (file-name-directory (or (getenv "XDG_CONFIG_HOME") "~/.config")) "dot/"))
+  (concat (or (getenv "XDG_CONFIG_HOME") "~/.config/") "dot/"))
 
 (defun kotct/dot-emacs-config-directory ()
   "Returns the directory name for where our machine-local Emacs subconfiguration directory should be."
@@ -8,7 +8,7 @@
         (emacs-subdir "emacs/"))
     (concat dot-config-dir emacs-subdir)))
 
-(let (emacs-config-directory (kotct/dot-emacs-config-directory))
-  (load (concat emacs-config-directory "init") 'noerror nil nil 'must-suffix))
+(let ((emacs-config-directory (kotct/dot-emacs-config-directory)))
+  (load (concat (file-name-directory emacs-config-directory) "init") 'noerror nil nil 'must-suffix))
 
 (provide 'machine-local)

--- a/.emacs.d/lisp/user/machine-local.el
+++ b/.emacs.d/lisp/user/machine-local.el
@@ -1,0 +1,5 @@
+(let ((dot-config (concat (file-name-directory (or (getenv "XDG_CONFIG_HOME") "~/.config/")) "dot/"))
+      (emacs-subdir "emacs/"))
+  (load (concat dot-config emacs-subdir "init") 'noerror nil nil 'must-suffix))
+
+(provide 'machine-local)

--- a/.emacs.d/lisp/user/machine-local.el
+++ b/.emacs.d/lisp/user/machine-local.el
@@ -1,5 +1,14 @@
-(let ((dot-config (concat (file-name-directory (or (getenv "XDG_CONFIG_HOME") "~/.config/")) "dot/"))
-      (emacs-subdir "emacs/"))
-  (load (concat dot-config emacs-subdir "init") 'noerror nil nil 'must-suffix))
+(defun kotct/dot-config-directory ()
+  "Returns the directory name for where our machine-local Dot configuration directory should be."
+  (concat (file-name-directory (or (getenv "XDG_CONFIG_HOME") "~/.config")) "dot/"))
+
+(defun kotct/dot-emacs-config-directory ()
+  "Returns the directory name for where our machine-local Emacs subconfiguration directory should be."
+  (let ((dot-config-dir (kotct/dot-config-directory))
+        (emacs-subdir "emacs/"))
+    (concat dot-config-dir emacs-subdir)))
+
+(let (emacs-config-directory (kotct/dot-emacs-config-directory))
+  (load (concat emacs-config-directory "init") 'noerror nil nil 'must-suffix))
 
 (provide 'machine-local)

--- a/.emacs.d/lisp/user/user-hub.el
+++ b/.emacs.d/lisp/user/user-hub.el
@@ -1,4 +1,5 @@
 (kotct/hub "user"
-           (user-config-system))
+           (user-config-system
+            machine-local))
 
 (provide 'user-hub)


### PR DESCRIPTION
Allows the user to add a machine-local config at `$XDG_CONFIG_HOME/dot/init.el`. If `$XDG_CONFIG_HOME` is not defined, it defaults to `~/.config/`.

*Closes #30*.