### PR TITLE
Add Language Support for Rust

### DIFF
--- a/.emacs.d/lisp/code/languages/language-hub.el
+++ b/.emacs.d/lisp/code/languages/language-hub.el
@@ -3,6 +3,7 @@
     elisp
     elixir
     ruby
+    rust
     java
     web-c)
   "A list of packages configured by the language-hub.")

--- a/.emacs.d/lisp/code/languages/rust.el
+++ b/.emacs.d/lisp/code/languages/rust.el
@@ -1,0 +1,19 @@
+(require 'indentation)
+
+;; Set `rust-indent-offset' to the `global-tab-width' value.
+(kotct/setq-default-tab rust-indent-offset)
+
+;; Add language support for Rust.
+(smart-tabs-add-language-support rust rust-mode-hook
+  ((rust-mode-indent-line . rust-indent-offset)))
+
+;; Use `indent-tabs-mode' in `rust-mode'
+(add-hook 'rust-mode-hook (lambda () (setf indent-tabs-mode t)))
+
+;; Turn on Rust support in Smart Tabs.
+(smart-tabs-insinuate 'rust)
+
+;; Don't indent `where' clauses in Rust.
+(setf rust-indent-where-clause nil)
+
+(provide 'rust)

--- a/.emacs.d/lisp/package/dependencies.el
+++ b/.emacs.d/lisp/package/dependencies.el
@@ -18,6 +18,7 @@
     highlight-symbol ;; navigate between and highlight symbols
     web-mode ;; for editing web files
     elixir-mode ;; for editing Elixir code
+    rust-mode ;; for editing Rust code
 
     ;; THEMES
     solarized-theme)


### PR DESCRIPTION
This also adds some configuration, including turning on smart-tabs-mode and turning off indenting `where` clauses.

*Closes #44.*