### PR TITLE
recover from failed user configs

### DIFF
--- a/.emacs.d/lisp/user/user-config-system.el
+++ b/.emacs.d/lisp/user/user-config-system.el
@@ -124,7 +124,7 @@ If USERNAME is nil, prompt for a username."
   (message "Loading for username: %s" username)
   (condition-case err
       (kotct/user-load-username username)
-    (test (message "Handling error, username: %s" kotct/user-current-username)
+    (error (message "Handling error, username: %s" kotct/user-current-username)
            (kotct/user-load-username kotct/user-current-username)
            (signal (car err) (cdr err))))
   ;; maybe then also reload/rerun all the hooks and stuff for open buffers


### PR DESCRIPTION
Without this change a failed user config causes `kotct/user-current-username` not to stay in sync with the current username which means all following calls to `kotct/user-switch-username` fail because of a failure in `kotct/user-unload-username`.
I believe this also resolves #7.