### PR TITLE
EditorConfig: Actually print warning if C Core not found

### DIFF
--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -23,7 +23,7 @@ Debug warning is suppressed if SUPPRESS is non-nil."
 
   (if (not suppress)
       (if (not (executable-find editorconfig-exec-path))
-          (lwarn '(editorconfig core) :debug "EditorConfig executable not found."))))
+          (message "EditorConfig C Core not found in `editorconfig-exec-path'."))))
 
 (kotct/editorconfig-check-for-core kotct/editorconfig-suppress-core-not-found-warning)
 


### PR DESCRIPTION
This is just a simple fix for #51.  I'm not sure if writing a message is the right way to do this, and if we wanted to use `lwarn`, we could, just changing `:debug` to `:warning`.  I think this follows our pattern for previous things.

*Closes #51.*