### PR TITLE
Add software license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Christopher Cooper, Samuel Mercier, and Kristofer Rye
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -206,3 +206,9 @@ Up for debate:
   global definitions) have docstrings that are properly formatted.
 - Comment when it's not immediately clear what the code is doing.
 - Write modular, clean, and fast code.
+
+## License
+
+`dot` is released and distributed under the terms of the MIT license.
+See [`LICENSE`](https://github.com/kotct/dot/blob/master/LICENSE) for
+more information.


### PR DESCRIPTION
This PR contains work prescribed in #49, adding a `LICENSE` file to the root of the project and a level-2 section in `README.md` containing a reference to said `LICENSE` file.

*Closes #49.*