### PR TITLE
Add Smartparens support

### DIFF
--- a/.emacs.d/lisp/code/code-hub.el
+++ b/.emacs.d/lisp/code/code-hub.el
@@ -1,6 +1,7 @@
 (kotct/hub "code"
            (editorconfig-c
             magit-c
+            smartparens-c
             indentation
             code-navigation))
 

--- a/.emacs.d/lisp/code/smartparens-c.el
+++ b/.emacs.d/lisp/code/smartparens-c.el
@@ -1,3 +1,5 @@
 (require 'smartparens-config)
 
+(smartparens-global-mode t)
+
 (provide 'smartparens-c)

--- a/.emacs.d/lisp/code/smartparens-c.el
+++ b/.emacs.d/lisp/code/smartparens-c.el
@@ -1,0 +1,3 @@
+(require 'smartparens-config)
+
+(provide 'smartparens-c)

--- a/.emacs.d/lisp/package/dependencies.el
+++ b/.emacs.d/lisp/package/dependencies.el
@@ -20,6 +20,7 @@
     elixir-mode ;; for editing Elixir code
     rust-mode ;; for editing Rust code
     buttercup ;; for tests
+    smartparens ;; for dealing with paired control flow symbols
 
     ;; THEMES
     solarized-theme)

--- a/.emacs.d/test/lisp/code/smartparens-c-test.el
+++ b/.emacs.d/test/lisp/code/smartparens-c-test.el
@@ -1,0 +1,5 @@
+(kotct/load-corresponding)
+
+(describe "smartparens config"
+  (it "turns the `smartparens-global-mode' minor mode on"
+    (expect smartparens-global-mode :to-be-truthy)))


### PR DESCRIPTION
For now, `smartparens-global-mode` is enabled and we are using the vanilla configuration provided by `smartparens`.  I'm open to feedback to make this work better for people and also to add new features, but bear in mind that these things can be added later on as we see the need for them.