### PR TITLE
Set gitignore-mode, gitattributes-mode, and gitconfig-mode as dependencies

### DIFF
--- a/.emacs.d/lisp/package/dependencies.el
+++ b/.emacs.d/lisp/package/dependencies.el
@@ -21,6 +21,9 @@
     rust-mode ;; for editing Rust code
     buttercup ;; for tests
     smartparens ;; for dealing with paired control flow symbols
+    gitignore-mode ;; for editing .gitignore files
+    gitattributes-mode ;; for editing .gitattributes files
+    gitconfig-mode ;; for editing .git/config files
 
     ;; THEMES
     solarized-theme)


### PR DESCRIPTION
This is a fairly straightforward change to add out-of-the-box support for editing (mostly just highlighting, but still) `.gitignore`, `.gitattributes`, and `.git/config` files.

*Closes #81.*