### PR TITLE
CI: Require `cl` at compile-time

### DIFF
--- a/.emacs.d/test/lisp/dot-tests.el
+++ b/.emacs.d/test/lisp/dot-tests.el
@@ -1,5 +1,7 @@
 (require 'buttercup)
 
+(eval-when-compile (require 'cl))
+
 (defun kotct/quietly-load-file (filename &optional throw-error)
   "Load FILENAME, but do not send a message on success.
 If loading throws an error, send a message with FILENAME and the error.


### PR DESCRIPTION
_Closes #85_

`cl` is required in order to use `assert`.  Here, we require `cl` when the code gets compiled in order to suppress errors in CI and allow our specs to actually run.

I will merge this later tonight unless I hear feedback otherwise.