### PR TITLE
Add force-load to kotct/switch-to-theme

### DIFF
--- a/.emacs.d/lisp/visual/theme.el
+++ b/.emacs.d/lisp/visual/theme.el
@@ -7,7 +7,8 @@
 
 If FORCE-LOAD is set, THEME is always loaded."
   (if kotct/current-theme (disable-theme kotct/current-theme))
-  (if (member theme custom-known-themes)
+  (if (and (not force-load)
+           (member theme custom-known-themes))
       (enable-theme theme)
     (load-theme theme 'no-confirm))
   (setf kotct/current-theme theme)

--- a/.emacs.d/lisp/visual/theme.el
+++ b/.emacs.d/lisp/visual/theme.el
@@ -2,8 +2,10 @@
   nil
   "The currently enabled theme.")
 
-(defun kotct/switch-to-theme (theme)
-  "Enable the theme THEME. Disable the current theme."
+(defun kotct/switch-to-theme (theme &optional force-load)
+  "Enable the theme THEME. Disable the current theme.
+
+If FORCE-LOAD is set, THEME is always loaded."
   (if kotct/current-theme (disable-theme kotct/current-theme))
   (if (member theme custom-known-themes)
       (enable-theme theme)


### PR DESCRIPTION
Adds `force-load` as an optional argument to `kotct/switch-to-theme`, which works as intended in my personal configuration.

*Closes #88.*