### PR TITLE
Update package archive priorities

### DIFF
--- a/.emacs.d/lisp/package/repositories.el
+++ b/.emacs.d/lisp/package/repositories.el
@@ -16,7 +16,7 @@
                "http://elpa.gnu.org/packages/"))
 
 (setf package-archive-priorities
-      '(("melpa-stable" . 10)
+      '(("melpa-stable" . 20)
         ("gnu" . 10)
         ("marmalade" . 10)
         ("melpa" . 0)))

--- a/.emacs.d/lisp/package/repositories.el
+++ b/.emacs.d/lisp/package/repositories.el
@@ -1,10 +1,5 @@
 (require 'package)
 
-;; Add MELPA repository
-(add-to-list 'package-archives
-             '("melpa" .
-               "http://melpa.milkbox.net/packages/"))
-
 ;; Add MELPA Stable
 (add-to-list 'package-archives
              '("melpa-stable" .
@@ -14,6 +9,11 @@
 (add-to-list 'package-archives
              '("gnu" .
                "http://elpa.gnu.org/packages/"))
+
+;; Add MELPA repository
+(add-to-list 'package-archives
+             '("melpa" .
+               "http://melpa.milkbox.net/packages/"))
 
 (setf package-archive-priorities
       '(("melpa-stable" . 20)

--- a/.emacs.d/lisp/package/repositories.el
+++ b/.emacs.d/lisp/package/repositories.el
@@ -18,7 +18,6 @@
 (setf package-archive-priorities
       '(("melpa-stable" . 20)
         ("gnu" . 10)
-        ("marmalade" . 10)
         ("melpa" . 0)))
 
 ;; (require 'packup)


### PR DESCRIPTION
This moves MELPA stable to the most trusted/prioritized position, and removes reference to Marmalade from the priority listing, as we have no configuration for it.

I think this might prevent collisions with versions, too.  We'll see.