### PR TITLE
Darwin: force use of sh as shell for path evaluation

### DIFF
--- a/.emacs.d/lisp/system/darwin.el
+++ b/.emacs.d/lisp/system/darwin.el
@@ -45,7 +45,7 @@ stuff.  This also respects the user's shell decision."
   ;; set, and the path should already be okay.
   (if (not (getenv "TERM_PROGRAM"))
       ;; Ask the shell to print out its value for $PATH.
-      (let ((path (shell-command-to-string "$SHELL -cl \"printf %s \\\"\\\$PATH\\\"\"")))
+      (let ((path (shell-command-to-string "/bin/sh -cl \"printf %s \\\"\\\$PATH\\\"\"")))
         ;; Set the PATH variable to this to match everything up.
         (setenv "PATH" path)
         ;; Split $PATH and store in `exec-path'.


### PR DESCRIPTION
It is thus recommended to use a `~/.profile` file to configure your `PATH` variable, since that is what `/bin/sh` loads.  Fish shell is non-POSIX-compliant, (which is on our list of things that we cannot assume) so by using this method of gathering information, we basically are broadening the possibilities to include all Linux/Mac machines.