### PR TITLE
add ability to run pre-load config

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1,5 +1,8 @@
 ;;; dot/.emacs
 
+;; load any absolute must-have code
+(load "~/.emacs-emergency" 'noerror 'nomessage 'nosuffix)
+
 ;; Initialize the package repository.
 (package-initialize)
 

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1,7 +1,7 @@
 ;;; dot/.emacs
 
 ;; load any absolute must-have code
-(load "~/.emacs-emergency" 'noerror 'nomessage 'nosuffix)
+(load "~/.emacs-preload" 'noerror 'nomessage 'nosuffix)
 
 ;; Initialize the package repository.
 (package-initialize)


### PR DESCRIPTION
At work I run emacs on WSL, using vcxsrv as my X server. This requires a line of emacs lisp in order to be able to even display the frame [[1]](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=31169#23). Putting this in my machine-local config meant that any time I broke the emacs config, my frame would not even display. This PR allows for adding arbitrary emacs lisp to a file `~/.emacs-emergency`, which will be loaded if it exists before any of the rest of the config begins to load.

The name of `~/.emacs-emergency` is somewhat arbitrary, but the location is not. In an effort to make sure this is _always_ loaded, I wanted to keep the code as simplistic as possible. When loading the machine-local configuration, we have a function or two to figure out where the dot config is (though usually it is just `~/.config/dot/`). I didn't want to do that, and hardcoding `~/.config/dot/emacs-emergency.el` also seemed like a bad idea in case someone redefines `$XDG_CONFIG_HOME`.

Comments or suggestions welcome, this is a basic idea at this point and both design and implementation feedback are needed.