### PR TITLE
Fix packup to correctly handle melpa-stable, and other fixes

### DIFF
--- a/.emacs.d/lisp/package/dependencies.el
+++ b/.emacs.d/lisp/package/dependencies.el
@@ -33,4 +33,9 @@
     solarized-theme)
   "A list of all packages required for operation.")
 
+(with-eval-after-load 'package
+  (setf package-pinned-packages
+        '(;; stable highlight-symbol is very old and VERY LOUD
+          (highlight-symbol . "melpa"))))
+
 (provide 'dependencies)

--- a/.emacs.d/lisp/package/packup.el
+++ b/.emacs.d/lisp/package/packup.el
@@ -15,7 +15,7 @@
 This is what the do-commands look for, and the flag the mark-commands store.")
 
 (defmacro kotct/with-stable-package-archive-contents (body)
-  "Run BODY, but if we don't have emacs 25 or later, let-bind
+  "Run BODY, but if we don't have Emacs 25 or later, let-bind
 a modified `package-archive-contents' that only includes the package-desc
 from the most-preferred repository."
   (if (version< emacs-version "25.1")
@@ -41,6 +41,7 @@ from the most-preferred repository."
 (defun kotct/package-latest-available (package)
   "Get the lastest-available package-desc for PACKAGE, preferring repositories
 as listed in `package-archive-priorities' or `kotct/package-ordered-archives'.
+
 Does not automatically refresh the package list."
   (if (version< emacs-version "25.1")
       ;; no package-archive-priorities, so use kotct/package-ordered-archives
@@ -63,15 +64,16 @@ Does not automatically refresh the package list."
     (cadr (assoc package package-archive-contents))))
 
 (defun kotct/package-up-to-date-p (package)
-  "Returns T if PACKAGE is installed and up-to-date.
+  "Return non-nil if PACKAGE is installed and up-to-date.
+
 Does not automatically refresh package list.
-Before emacs 25, we have to manually check in preferred-repository order."
+Before Emacs 25, we have to manually check in preferred-repository order."
   (let ((latest (kotct/package-latest-available package)))
     (when latest
       (package-installed-p package (package-desc-version latest)))))
 
 (defun kotct/packup-insert-package-row (package-name package-desc-version)
-  "Inserts a package row into current buffer."
+  "Insert a package row into current buffer."
   (let ((inhibit-read-only t))
     (insert (format "[%c] %s -> %s\n" kotct/packup-marker-char package-name package-desc-version))))
 
@@ -128,7 +130,7 @@ as in '[x]'."
 
 (defun kotct/packup-get-package-name ()
   "Get package name on current line.
-Returns \"\" if there is no package name on the line."
+Return \"\" if there is no package name on the line."
   (save-excursion
     (beginning-of-line)
     (forward-char 4)
@@ -221,7 +223,7 @@ contents of the buffer."
         (apply #'kotct/packup-insert-package-row (list package (package-desc-version (kotct/package-latest-available package))))))))
 
 (defun kotct/packup-refresh ()
-  "Refreshes packages in current buffer."
+  "Refresh packages in current packup buffer."
   (interactive)
   (when (eq major-mode 'packup-mode)
     (let ((inhibit-read-only t))
@@ -253,7 +255,7 @@ contents of the buffer."
   "The keymap for packup-mode.")
 
 (defun kotct/packup-initialize-buffer ()
-  "Initializes the packup buffer."
+  "Initialize the packup buffer."
   (kill-all-local-variables)
   (use-local-map packup-mode-map)
   (setf major-mode 'packup-mode
@@ -264,7 +266,7 @@ contents of the buffer."
 
 ;;;###autoload
 (defun kotct/packup ()
-  "Creates an interactive buffer to install/update packages."
+  "Create an interactive buffer to install/update packages."
   (interactive)
   (let ((old-buf (current-buffer))
         (buffer (get-buffer-create "*packup*")))
@@ -279,8 +281,9 @@ contents of the buffer."
 
 ;;;###autoload
 (defun kotct/packup-install-dependencies (no-refresh &optional update auto-update)
-  "Installs the dependencies.
+  "Install the dependencies.
 With a non-nil or prefix arg NO-REFRESH, do not refresh package list.
+
 If UPDATE is non-nil, out-of-date packages will be added to install list.
 If AUTO-UPDATE is non-nil, out-of-date/uninstalled packages will be updated."
   (interactive "P")

--- a/.emacs.d/lisp/package/packup.el
+++ b/.emacs.d/lisp/package/packup.el
@@ -213,7 +213,10 @@ contents of the buffer."
   (when (eq major-mode 'packup-mode)
     (let ((inhibit-read-only t))
       (erase-buffer))
-    (kotct/packup-initialize-buffer-contents)))
+    (kotct/packup-initialize-buffer-contents)
+    (when (= (point-min) (point-max))
+      (let ((inhibit-read-only t))
+        (insert "Everything is up to date!\n")))))
 
 (defun kotct/packup-help ()
   "Show packup help."

--- a/.emacs.d/lisp/package/packup.el
+++ b/.emacs.d/lisp/package/packup.el
@@ -282,13 +282,13 @@ If AUTO-UPDATE is non-nil, out-of-date/uninstalled packages will be updated."
                           (message "Dependency installation completed."))
                  (let ((manual-install-list nil))
                    (dolist (package-cons install-list)
-                     (if (y-or-n-p (format "Package %s is %s. Install it? "
+                     (if (y-or-n-p (format "Package %s is %s. Install %s? "
                                            (package-desc-name (car package-cons))
                                            (if (cdr package-cons)
-                                               (format "out of date (%s -> %s)"
-                                                       (package-version-join (package-desc-version (cdr package-cons)))
-                                                       (package-version-join (package-desc-version (car package-cons))))
-                                             "missing")))
+                                               (format "out of date (%s)"
+                                                       (package-version-join (package-desc-version (cdr package-cons))))
+                                             "missing")
+                                           (package-version-join (package-desc-version (car package-cons)))))
                          (add-to-list 'manual-install-list package-cons)))
                    (progn (package-download-transaction
                            (kotct/with-stable-package-archive-contents

--- a/.emacs.d/lisp/package/packup.el
+++ b/.emacs.d/lisp/package/packup.el
@@ -67,6 +67,8 @@ Before emacs 25, we have to manually check in preferred-repository order."
     (insert (format "[%c] %s -> %s\n" kotct/packup-marker-char package-name package-desc-version))))
 
 (defun kotct/packup-mark-packages-in-region (start end)
+  "Mark all packages in the current packup buffer that are between
+START and END. START should be at the beginning of a line."
   (let ((inhibit-read-only t))
     (if (> start end)
         (error "start > end"))
@@ -87,6 +89,8 @@ Before emacs 25, we have to manually check in preferred-repository order."
     (forward-line)))
 
 (defun kotct/packup-marker-regexp ()
+  "Return a regexp to search for `kotct/packup-marker-char' surrounded by quotes,
+as in '[x]'."
   (concat "^\\[" (regexp-quote (char-to-string kotct/packup-marker-char)) "\\]"))
 
 (defmacro kotct/packup-map-over-marks (body)
@@ -114,7 +118,7 @@ Before emacs 25, we have to manually check in preferred-repository order."
      results))
 
 (defun kotct/packup-get-package-name ()
-  "Gets package name on current line.
+  "Get package name on current line.
 Returns \"\" if there is no package name on the line."
   (save-excursion
     (beginning-of-line)
@@ -127,7 +131,7 @@ Returns \"\" if there is no package name on the line."
         ""))))
 
 (defun kotct/packup-do-update ()
-  "Executes update in current buffer."
+  "Execute update in current buffer."
   (interactive)
   (let ((inhibit-read-only t))
     (save-excursion
@@ -167,18 +171,25 @@ If an prefix-arg is passed unmark ARG times."
     (kotct/packup-mark arg interactive)))
 
 (defun kotct/packup-mark-all ()
+  "Mark all packages in the current packup buffer."
   (interactive)
   (save-excursion
     (kotct/packup-mark-packages-in-region (point-min) (point-max))))
 
 
 (defun kotct/packup-unmark-all ()
+  "Unmark all packages in the current packup buffer."
   (interactive)
   (save-excursion
     (let ((kotct/packup-marker-char ?\040))
       (kotct/packup-mark-packages-in-region (point-min) (point-max)))))
 
 (defun kotct/packup-initialize-buffer-contents ()
+  "Initialize contents of the current packup buffer.
+
+This refreshes `package-archive-contents' and finds all packages that need
+updating or installing. It then uses this information to write the
+contents of the buffer."
   (let ((inhibit-read-only t))
     (kill-region (point-min) (point-max)))
   (package-refresh-contents)
@@ -196,6 +207,7 @@ If an prefix-arg is passed unmark ARG times."
     (kotct/packup-initialize-buffer-contents)))
 
 (defun kotct/packup-help ()
+  "Show packup help."
   (interactive)
   (message "g-refresh m-mark u-unmark x-execute ?-help"))
 
@@ -208,7 +220,8 @@ If an prefix-arg is passed unmark ARG times."
     (define-key map "x" #'kotct/packup-do-update)
     (define-key map "g" #'kotct/packup-refresh)
     (define-key map "?" #'kotct/packup-help)
-    map))
+    map)
+  "The keymap for packup-mode.")
 
 (defun kotct/packup-initialize-buffer ()
   "Initializes the packup buffer."

--- a/.emacs.d/lisp/package/packup.el
+++ b/.emacs.d/lisp/package/packup.el
@@ -187,16 +187,6 @@ If an prefix-arg is passed unmark ARG times."
       (when (not (kotct/package-up-to-date-p package))
         (apply #'kotct/packup-insert-package-row (list package (package-desc-version (kotct/package-latest-available package))))))))
 
-
-(defun kotct/packup-initialize-buffer ()
-  "Initializes the packup buffer."
-  (kill-all-local-variables)
-  (use-local-map packup-mode-map)
-  (setf major-mode 'packup-mode
-        mode-name "Packup"
-        buffer-read-only t)
-  (kotct/packup-initialize-buffer-contents))
-
 (defun kotct/packup-refresh ()
   "Refreshes packages in current buffer."
   (interactive)
@@ -219,6 +209,16 @@ If an prefix-arg is passed unmark ARG times."
     (define-key map "g" #'kotct/packup-refresh)
     (define-key map "?" #'kotct/packup-help)
     map))
+
+(defun kotct/packup-initialize-buffer ()
+  "Initializes the packup buffer."
+  (kill-all-local-variables)
+  (use-local-map packup-mode-map)
+  (setf major-mode 'packup-mode
+        mode-name "Packup"
+        buffer-read-only t)
+  (kotct/packup-initialize-buffer-contents))
+
 
 ;;;###autoload
 (defun kotct/packup ()

--- a/.emacs.d/lisp/package/packup.el
+++ b/.emacs.d/lisp/package/packup.el
@@ -10,7 +10,7 @@
 
 (package-initialize)
 
-(defvar kotct/packup-marker-char ?x
+(defvar kotct/packup-marker-char ?*
   "In Packup, the current mark character.
 This is what the do-commands look for, and the flag the mark-commands store.")
 
@@ -152,7 +152,7 @@ Returns \"\" if there is no package name on the line."
 (defun kotct/packup-mark (arg &optional interactive)
   "Mark the package for update at point in the Packup buffer.
 If a region is selected, mark all the packages in the region.
-If an prefix-arg is passed mark ARG times."
+If a prefix-arg is passed mark ARG times."
   (interactive (list current-prefix-arg t))
   (cond
    ((use-region-p)
@@ -169,7 +169,8 @@ If an prefix-arg is passed mark ARG times."
        (lambda ()
          (forward-char 1)
          (delete-char 1)
-         (insert kotct/packup-marker-char)))))))
+         (insert kotct/packup-marker-char)))
+      (forward-char)))))
 
 (defun kotct/packup-unmark (arg &optional interactive)
   "Unmark the package for update at point in the Packup buffer.
@@ -193,6 +194,18 @@ If an prefix-arg is passed unmark ARG times."
     (let ((kotct/packup-marker-char ?\040))
       (kotct/packup-mark-packages-in-region (point-min) (point-max)))))
 
+(defun kotct/packup-next ()
+  "Go to the next package in the current packup buffer."
+  (interactive)
+  (move-beginning-of-line 2)
+  (forward-char))
+
+(defun kotct/packup-prev ()
+  "Go to the previous package in the current packup buffer."
+  (interactive)
+  (move-beginning-of-line 0)
+  (forward-char))
+
 (defun kotct/packup-initialize-buffer-contents ()
   "Initialize contents of the current packup buffer.
 
@@ -214,9 +227,10 @@ contents of the buffer."
     (let ((inhibit-read-only t))
       (erase-buffer))
     (kotct/packup-initialize-buffer-contents)
-    (when (= (point-min) (point-max))
-      (let ((inhibit-read-only t))
-        (insert "Everything is up to date!\n")))))
+    (if (= (point-min) (point-max))
+        (let ((inhibit-read-only t))
+          (insert "Everything is up to date!\n"))
+      (goto-char 2))))
 
 (defun kotct/packup-help ()
   "Show packup help."
@@ -230,8 +244,11 @@ contents of the buffer."
     (define-key map "u" #'kotct/packup-unmark)
     (define-key map "U" #'kotct/packup-unmark-all)
     (define-key map "x" #'kotct/packup-do-update)
+    (define-key map "n" #'kotct/packup-next)
+    (define-key map "p" #'kotct/packup-prev)
     (define-key map "g" #'kotct/packup-refresh)
     (define-key map "?" #'kotct/packup-help)
+    (define-key map "q" #'quit-window)
     map)
   "The keymap for packup-mode.")
 
@@ -257,6 +274,7 @@ contents of the buffer."
         (progn
           (kill-buffer buffer)
           (message "Nothing to update!"))
+      (goto-char 2)
       (pop-to-buffer-same-window buffer))))
 
 ;;;###autoload

--- a/.emacs.d/lisp/package/packup.el
+++ b/.emacs.d/lisp/package/packup.el
@@ -18,7 +18,6 @@ This is what the do-commands look for, and the flag the mark-commands store.")
   "Run BODY, but if we don't have emacs 25 or later, let-bind
 a modified `package-archive-contents' that only includes the package-desc
 from the most-preferred repository"
-  (message "%s" emacs-version)
   (if (version< emacs-version "25.1")
       `(let ((package-archive-contents
               (mapcar (lambda (pkg)

--- a/.emacs.d/lisp/package/repositories.el
+++ b/.emacs.d/lisp/package/repositories.el
@@ -15,10 +15,21 @@
              '("melpa" .
                "https://melpa.org/packages/"))
 
-(setf package-archive-priorities
-      '(("melpa-stable" . 20)
-        ("gnu" . 10)
-        ("melpa" . 0)))
+(if (version< emacs-version "25.1")
+    (defvar kotct/package-ordered-archives
+      '("melpa-stable"
+        "gnu"
+        "melpa")
+      "Define the preferred order of package repositories.
+If a repository is earlier in the list, it is preferred over
+a repository that is later in the list.
+
+This variable is succeeded by `package-archive-priorities'
+in emacs 25 and later.")
+  (setf package-archive-priorities
+        '(("melpa-stable" . 20)
+          ("gnu" . 10)
+          ("melpa" . 0))))
 
 ;; (require 'packup)
 

--- a/.emacs.d/lisp/package/repositories.el
+++ b/.emacs.d/lisp/package/repositories.el
@@ -15,22 +15,20 @@
              '("melpa" .
                "https://melpa.org/packages/"))
 
-(if (version< emacs-version "25.1")
-    (defvar kotct/package-ordered-archives
-      '("melpa-stable"
-        "gnu"
-        "melpa")
-      "Define the preferred order of package repositories.
+(defvar kotct/package-ordered-archives
+  '("melpa-stable"
+    "gnu"
+    "melpa")
+  "Define the preferred order of package repositories.
 If a repository is earlier in the list, it is preferred over
 a repository that is later in the list.
 
-This variable is succeeded by `package-archive-priorities'
-in emacs 25 and later.")
+This variable is succeeded by `package-archive-priorities' in emacs 25 and later.")
+
+(when (version<= "25.1" emacs-version)
   (setf package-archive-priorities
         '(("melpa-stable" . 20)
           ("gnu" . 10)
           ("melpa" . 0))))
-
-;; (require 'packup)
 
 (provide 'repositories)


### PR DESCRIPTION
That's right: packup no longer tries to install the latest melpa even though you told it to use melpa-stable! Woo!

Other things I like are added. Feel free to complain if you don't like them.

This resolves #99.