### PR TITLE
Let TRAMP choose its own default

### DIFF
--- a/.emacs.d/lisp/file/tramp-c.el
+++ b/.emacs.d/lisp/file/tramp-c.el
@@ -1,9 +1,5 @@
 ;;; C-c C-f: find the current file as sudo
 
-;; ssh is faster than the default scp
-(with-eval-after-load 'tramp
-  (setf tramp-default-method "ssh"))
-
 (defun kotct/sudo-edit (&optional arg)
   "Edit currently visited file as root.
 With a prefix ARG prompt for a file to visit.


### PR DESCRIPTION
Per #103, don't be opinionated about the default TRAMP protocol. scp seems fine, and if you really want to, it's very easy to type `/ssh` instead of `/-`.

Closes #103.