### PR TITLE
Add support for display-line-numbers-mode

### DIFF
--- a/.emacs.d/lisp/visual/line-numbers-c.el
+++ b/.emacs.d/lisp/visual/line-numbers-c.el
@@ -32,10 +32,11 @@ it generally works better."
     (global-display-line-numbers-mode 1)
 
     ;; add some hooks to turn off display-line-numbers mode
-    (add-hook 'dired-mode-hook #'kotct/display-line-numbers--turn-off)
-    (add-hook 'git-commit-mode-hook #'kotct/display-line-numbers--turn-off)
-    (add-hook 'magit-mode-hook #'kotct/display-line-numbers--turn-off)
-    (add-hook 'package-menu-mode-hook #'kotct/display-line-numbers--turn-off)))
+    (dolist (hook '(dired-mode-hook
+                    git-commit-mode-hook
+                    magit-mode-hook
+                    package-menu-mode-hook))
+      (add-hook hook #'kotct/display-line-numbers--turn-off))))
 
 (if (fboundp #'display-line-numbers-mode)
     (kotct/line-numbers--set-up-display-line-numbers)

--- a/.emacs.d/lisp/visual/line-numbers-c.el
+++ b/.emacs.d/lisp/visual/line-numbers-c.el
@@ -37,7 +37,7 @@ it generally works better."
     (add-hook 'magit-mode-hook #'kotct/display-line-numbers--turn-off)
     (add-hook 'package-menu-mode-hook #'kotct/display-line-numbers--turn-off)))
 
-(if (not (version< emacs-version "26.1"))
+(if (fboundp #'display-line-numbers-mode)
     (kotct/line-numbers--set-up-display-line-numbers)
   (kotct/line-numbers--set-up-linum))
 

--- a/.emacs.d/lisp/visual/line-numbers-c.el
+++ b/.emacs.d/lisp/visual/line-numbers-c.el
@@ -1,17 +1,24 @@
-;; enable linum globally
-(global-linum-mode 1)
+(defun kotct/line-numbers--set-up-linum ()
+  "Sets up `linum-mode' to run globally except in a few cases."
+  (progn
+    ;; enable linum globally
+    (global-linum-mode 1)
 
-;; use a lambda to generate the linum formatting
-;; this will use the minimum number of columns,
-;; but also always right-align
-(setq linum-format (lambda (line)
-                     (let* ((w (length (number-to-string (count-lines (point-min) (point-max)))))
-                            (thing (concat " %" (number-to-string (max 2 w)) "d ")))
-                       (propertize (format thing line) 'face 'linum))))
+    ;; use a lambda to generate the linum formatting
+    ;; this will use the minimum number of columns,
+    ;; but also always right-align
+    (setq linum-format (lambda (line)
+                         (let* ((w (length (number-to-string (count-lines (point-min) (point-max)))))
+                                (thing (concat " %" (number-to-string (max 2 w)) "d ")))
+                           (propertize (format thing line) 'face 'linum))))
 
-;; disable linum in certain modes
-(require 'linum-off)
-(add-to-list 'linum-disabled-modes-list 'package-menu-mode)
-(add-to-list 'linum-disabled-modes-list 'magit--mode)
+    ;; disable linum in certain modes
+    (require 'linum-off)
+    (add-to-list 'linum-disabled-modes-list 'package-menu-mode)
+    (add-to-list 'linum-disabled-modes-list 'magit--mode)))
+
+(if (not (version< emacs-version "26.1"))
+    nil
+  (kotct/line-numbers--set-up-linum))
 
 (provide 'line-numbers-c)

--- a/.emacs.d/lisp/visual/line-numbers-c.el
+++ b/.emacs.d/lisp/visual/line-numbers-c.el
@@ -17,8 +17,28 @@
     (add-to-list 'linum-disabled-modes-list 'package-menu-mode)
     (add-to-list 'linum-disabled-modes-list 'magit--mode)))
 
+(defun kotct/display-line-numbers--turn-off ()
+  "Turns off `display-line-numbers-mode' for the current buffer."
+  (display-line-numbers-mode -1))
+
+(defun kotct/line-numbers--set-up-display-line-numbers ()
+  "Sets up `display-line-numbers-mode'.
+
+This mode was added in Emacs 26.1 and is recommended over `linum-mode' because
+it generally works better."
+  (progn
+    ;; inhibit global-linum-mode
+    (global-linum-mode -1)
+    (global-display-line-numbers-mode 1)
+
+    ;; add some hooks to turn off display-line-numbers mode
+    (add-hook 'dired-mode-hook #'kotct/display-line-numbers--turn-off)
+    (add-hook 'git-commit-mode-hook #'kotct/display-line-numbers--turn-off)
+    (add-hook 'magit-mode-hook #'kotct/display-line-numbers--turn-off)
+    (add-hook 'package-menu-mode-hook #'kotct/display-line-numbers--turn-off)))
+
 (if (not (version< emacs-version "26.1"))
-    nil
+    (kotct/line-numbers--set-up-display-line-numbers)
   (kotct/line-numbers--set-up-linum))
 
 (provide 'line-numbers-c)

--- a/.emacs.d/lisp/visual/line-numbers-c.el
+++ b/.emacs.d/lisp/visual/line-numbers-c.el
@@ -14,4 +14,4 @@
 (add-to-list 'linum-disabled-modes-list 'package-menu-mode)
 (add-to-list 'linum-disabled-modes-list 'magit--mode)
 
-(provide 'linum-c)
+(provide 'line-numbers-c)

--- a/.emacs.d/lisp/visual/visual-hub.el
+++ b/.emacs.d/lisp/visual/visual-hub.el
@@ -1,5 +1,5 @@
 (kotct/hub "visual"
-           (linum-c
+           (line-numbers-c
             startup-c
             frame-c
             text-visuals


### PR DESCRIPTION
This PR moves `linum-c` to `line-numbers-c` to make it more general-purpose, and extracts existing logic into a helper function before adding another helper method.

The new functionality on 26.1 is to disable `global-linum-mode` (probably not necessary) before enabling `global-display-line-numbers-mode`.  Then, hooks are added to turn off `display-line-numbers-mode` on a few modes that don't seem to like it, such as `dired-mode`, `git-commit-mode`, `magit`-derived modes, and `package-menu-mode`.

Open to further requests or stylistic feedback.  Otherwise, I would say ToT is ready to use in production.

Resolves #98.