### PR TITLE
Prefer the UTF-8 coding system

### DIFF
--- a/.emacs.d/lisp/file/file-content.el
+++ b/.emacs.d/lisp/file/file-content.el
@@ -3,4 +3,7 @@
 ;; M-x set-variable RET require-final-newline RET nil RET
 (setq-default require-final-newline t)
 
+;; UTF-8 is a sane default
+(prefer-coding-system 'utf-8)
+
 (provide 'file-content)


### PR DESCRIPTION
Pretty self-explanatory. I can't think of a reason why not.

Emacs seems to already inherently choose UTF-8 as its default encoding, but it doesn't know that that is preferred by the user.

Do we want this, or would we rather just let Emacs make the decisions? I'm honestly not sure.