### PR TITLE
web-c: Add .mjs to the list of exts for web-mode

### DIFF
--- a/.emacs.d/lisp/code/languages/web-c.el
+++ b/.emacs.d/lisp/code/languages/web-c.el
@@ -2,6 +2,7 @@
 (add-to-list 'auto-mode-alist '("\\.scss\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.sass\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.css\\'" . web-mode))
+(add-to-list 'auto-mode-alist '("\\.mjs\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.jsx?\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.jsonp?\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.phtml\\'" . web-mode))


### PR DESCRIPTION
This is the JS-person way of signifying that the file is exclusively using the "future" modules-import syntax lol