### PR TITLE
init: Remove unnecessary call to package-initialize

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -3,9 +3,6 @@
 ;; load any absolute must-have code
 (load "~/.emacs-preload" 'noerror 'nomessage 'nosuffix)
 
-;; Initialize the package repository.
-(package-initialize)
-
 ;; Create variable to determine if we are in dev mode or not.
 ;; (Set this in your user hub.)
 (defvar kotct/dev-mode


### PR DESCRIPTION
According to Emacs 26.x+, this is not necessary.  It certainly seems strange, but making this change does not affect the results of startup at all for me, besides shaving just a little bit of time off.

Since we `require` every ELPA package before we configure it, this shouldn't have any danger of affecting reachability, unless that assumption is violated anywhere.

Resolves #123.