### PR TITLE
add interactive commands for updating kotct/dot and user configs

### DIFF
--- a/.emacs.d/lisp/package/git-update.el
+++ b/.emacs.d/lisp/package/git-update.el
@@ -20,6 +20,13 @@
   "Fetch DIRECTORY's origin/master and diff to see if there are any new remote commits."
   (not (string= (kotct/git-repository-diff directory) "")))
 
+(defun kotct/git-current-branch (directory)
+  (let ((default-directory directory))
+    (kotct/run-git "branch" "--show-current")))
+
+(defun kotct/git-branch-is-master (directory)
+  (string= (string-trim (kotct/git-current-branch directory)) "master"))
+
 (defun kotct/user-fetch-config (username)
   "Fetch USERNAME's personal config from GitHub, out of the repository USERNAME/.emacs."
   (message "fetching config for %s" username)
@@ -30,40 +37,45 @@
 (defun kotct/update-git-repository (directory &optional auto-update)
   "Fetches changes in DIRECTORY, and pulls from DIRECTORY if instructed by the user or AUTO-UPDATE is true.
 Returns true if an update occured."
-  (if (kotct/git-repository-is-behind directory)
-      ;; create new buffer and save old buffer
-      (let ((old-buffer (current-buffer))
-            (buffer (get-buffer-create (format "*Diff %s*" directory))))
-        (set-buffer buffer)
-        (let ((inhibit-read-only t))
-          ;; erase, fill, and show new buffer
-          (erase-buffer)
-          (insert (format "%s" (kotct/git-repository-diff directory)))
-          (pop-to-buffer-same-window buffer)
-          ;; prompt user about updating and update if they want
-          (setf updating (or auto-update
-                  (y-or-n-p (format "Pull the most recent changes to %s?" directory))))
-          (if updating
-              (let ((default-directory directory))
-                (kotct/run-git "pull" "--rebase" "origin" "master")
-                (message (format "%s updated!" directory)))
-            (message "Okay we promise we didn't do anything!"))
-          ;; reset buffer what not
-          (kill-buffer buffer)
-          (set-buffer old-buffer)
-          updating))
-    (progn (message (format "%s is up to date." directory))
-           nil)))
+  (if (kotct/git-branch-is-master directory)
+      (if (kotct/git-repository-is-behind directory)
+          ;; create new buffer and save old buffer
+          (let ((old-buffer (current-buffer))
+                (buffer (get-buffer-create (format "*Diff %s*" directory))))
+            (set-buffer buffer)
+            (let ((inhibit-read-only t))
+              ;; erase, fill, and show new buffer
+              (erase-buffer)
+              (insert (format "%s" (kotct/git-repository-diff directory)))
+              (pop-to-buffer-same-window buffer)
+              ;; prompt user about updating and update if they want
+              (let updating (or auto-update
+                                (y-or-n-p (format "Pull the most recent changes to %s?" directory))))
+              (if updating
+                  (let ((default-directory directory))
+                    (kotct/run-git "pull" "--rebase" "origin" "master")
+                    (message (format "%s updated!" directory)))
+                (message "Okay we promise we didn't do anything!"))
+              ;; reset buffer what not
+              (kill-buffer buffer)
+              (set-buffer old-buffer)
+              updating))
+        (message (format "%s is up to date." directory))
+        nil)
+    (error (format "Error: kotct/update-git-repository doesn't support updating non-master branches, and %s is on branch %s."
+                   directory
+                   (string-trim (kotct/git-current-branch directory))))
+    nil))
 
 ;;;###autoload
 (defun kotct/update-dot-config (&optional auto-update)
-  "Update USERNAME's personal config git repository if the USERNAME's personal config is out of date.
+  "Update the doct config git repository if the dot config git repository is out of date.
 Will auto update if AUTO-UPDATE is true."
   (interactive "P")
   (kotct/update-git-repository kotct/directory auto-update))
 
 ;;;###autoload
-(defun kotct/update-user-config (&optional username auto-update)
+(defun kotct/update-user-config (&optional auto-update username)
   "Update USERNAME's personal config git repository if the USERNAME's personal config is out of date.
 If USERNAME is nil, prompt for a username.
 Will auto update if AUTO-UPDATE is true."
@@ -71,9 +83,11 @@ Will auto update if AUTO-UPDATE is true."
   (unless username
     (setf username
           (kotct/user-ask-username "Update config for: " 'require-match)))
-  (if (and (kotct/update-git-repository (format "~/.emacs.d/lisp/user/users/%s" username) auto-update)
-           (eq username kotct/user-current-username))
-      ;; reload the config
-      (kotct/user-switch-username username)))
+  (if (kotct/update-git-repository (format "~/.emacs.d/lisp/user/users/%s" username) auto-update)
+      (if (eq username kotct/user-current-username)
+          ;; reload the config
+          (kotct/user-switch-username username)
+        (message (format "%s's config has been udpated!" username)))
+    (message (format "%s's config is up to date!" username))))
 
 (provide 'git-update)

--- a/.emacs.d/lisp/package/git-update.el
+++ b/.emacs.d/lisp/package/git-update.el
@@ -49,17 +49,19 @@ Returns true if an update occured."
               (insert (format "%s" (kotct/git-repository-diff directory)))
               (pop-to-buffer-same-window buffer)
               ;; prompt user about updating and update if they want
-              (let updating (or auto-update
-                                (y-or-n-p (format "Pull the most recent changes to %s?" directory))))
-              (if updating
-                  (let ((default-directory directory))
-                    (kotct/run-git "pull" "--rebase" "origin" "master")
-                    (message (format "%s updated!" directory)))
-                (message "Okay we promise we didn't do anything!"))
-              ;; reset buffer what not
-              (kill-buffer buffer)
-              (set-buffer old-buffer)
-              updating))
+              (let ((updating (or auto-update
+                                  (y-or-n-p (format "Pull the most recent changes to %s?" directory)))))
+
+                (if updating
+                    (let ((default-directory directory))
+                      (kotct/run-git "pull" "--rebase" "origin" "master")
+                      (message (format "%s updated!" directory)))
+                  (message "Okay we promise we didn't do anything!"))
+
+                ;; reset buffer what not
+                (kill-buffer buffer)
+                (set-buffer old-buffer)
+                updating)))
         (message (format "%s is up to date." directory))
         nil)
     (error (format "Error: kotct/update-git-repository doesn't support updating non-master branches, and %s is on branch %s."

--- a/.emacs.d/lisp/package/git-update.el
+++ b/.emacs.d/lisp/package/git-update.el
@@ -1,0 +1,78 @@
+;;; THIS FILE IS NOT LOADED AT STARTUP.
+;;; This file is autoloaded on the following symbols:
+;;;  kotct/update-dot-config
+;;;  kotct/update-user-config
+
+(require  'user-config-system)
+
+(package-initialize)
+
+(defun kotct/git-repository-diff (directory)
+  "Fetches in DIRECTORY and returns the difference between the common ancestor of HEAD and origin/master in DIRECTORY."
+  (let ((default-directory directory))
+    (kotct/run-git "fetch" "origin" "master")
+    (kotct/run-git "diff" "HEAD...origin/master")))
+
+(defun kotct/git-repository-is-behind (directory)
+  "Fetch DIRECTORY's origin/master and diff to see if there are any new remote commits."
+  (not (string= (kotct/git-repository-diff directory) "")))
+
+(defun kotct/user-fetch-config (username)
+  "Fetch USERNAME's personal config from GitHub, out of the
+repository USERNAME/.emacs."
+  (message "fetching config for %s" username)
+  (let ((default-directory "~/.emacs.d/lisp/user/users/")
+        (url (format "https://github.com/%s/.emacs.git" username)))
+    (kotct/run-git "clone" url username)))
+
+(defun kotct/update-git-repository (directory &optional auto-update)
+  "Fetches changes in DIRECTORY, and pulls from DIRECTORY if instructed by the user or AUTO-UPDATE is true.
+Returns true if an update occured."
+  (if (kotct/git-repository-is-behind directory)
+      ;; create new buffer and save old buffer
+      (let ((old-buffer (current-buffer))
+            (buffer (get-buffer-create (format "*Diff %s*" directory))))
+        (set-buffer buffer)
+        (let ((inhibit-read-only t))
+          ;; erase, fill, and show new buffer
+          (erase-buffer)
+          (insert (format "%s" (kotct/git-repository-diff directory)))
+          (pop-to-buffer-same-window buffer)
+          ;; prompt user about updating and update if they want
+          (setf updating (or auto-update
+                  (y-or-n-p (format "Pull the most recent changes to %s?" directory))))
+          (if updating
+              (let ((default-directory directory))
+                (kotct/run-git "pull" "origin" "master")
+                (message (format "%s updated!" directory)))
+            (message "Okay we promise we didn't do anything!"))
+          ;; reset buffer what not
+          (kill-buffer buffer)
+          (set-buffer old-buffer)
+          updating))
+    (progn (message (format "%s is up to date." directory))
+           nil)))
+
+;;;###autoload
+(defun kotct/update-user-config (&optional username auto-update)
+  "Update USERNAME's personal config git repository if the USERNAME's personal config is out of date.
+If USERNAME is nil, prompt for a username.
+Will auto update if AUTO-UPDATE is true."
+  (interactive "P")
+  (unless username
+    (setf username
+          (kotct/user-ask-username "Update config for: " 'require-match)))
+  (if (and (kotct/update-git-repository (format "~/.emacs.d/lisp/user/users/%s" username) auto-update)
+
+           (eq username kotct/user-current-username))
+      ;; reload the config
+      (kotct/user-switch-username username)))
+
+;;;###autoload
+(defun kotct/update-dot-config (&optional auto-update)
+  "Update USERNAME's personal config git repository if the USERNAME's personal config is out of date.
+Will auto update if AUTO-UPDATE is true."
+  (interactive "P")
+  (kotct/update-git-repository kotct/directory auto-update))
+
+(provide 'git-update)

--- a/.emacs.d/lisp/package/package-hub.el
+++ b/.emacs.d/lisp/package/package-hub.el
@@ -2,6 +2,7 @@
            (dependencies
             repositories
             verification)
-           (packup))
+           (packup
+	        git-update))
 
 (provide 'package-hub)

--- a/.emacs.d/lisp/package/package-hub.el
+++ b/.emacs.d/lisp/package/package-hub.el
@@ -3,6 +3,6 @@
             repositories
             verification)
            (packup
-	        git-update))
+            git-update))
 
 (provide 'package-hub)

--- a/.emacs.d/lisp/user/user-config-system.el
+++ b/.emacs.d/lisp/user/user-config-system.el
@@ -8,9 +8,6 @@
   "~/.emacs.d/lisp/user/default-username"
   "The file that sets the default username for the machine.  (Ignored by git.)")
 
-(defvar kotct/directory "~/.emacs.d"
-  "The path to your instance of kotct/dot or one of it's subdirectories.")
-
 (defmacro kotct/personal-packages (&rest packages)
   "Appends PACKAGES to `kotct/dependency-list'"
   (setf kotct/dependency-list (append kotct/dependency-list packages))

--- a/.emacs.d/lisp/user/user-config-system.el
+++ b/.emacs.d/lisp/user/user-config-system.el
@@ -8,6 +8,9 @@
   "~/.emacs.d/lisp/user/default-username"
   "The file that sets the default username for the machine.  (Ignored by git.)")
 
+(defvar kotct/directory "~/.emacs.d"
+  "The path to your instance of kotct/dot or one of it's subdirectories.")
+
 (defmacro kotct/personal-packages (&rest packages)
   "Appends PACKAGES to `kotct/dependency-list'"
   (setf kotct/dependency-list (append kotct/dependency-list packages))
@@ -25,28 +28,6 @@
         (if (zerop exit-code)
             (buffer-string)
           (error "Error running git %s\n%s" args (buffer-string)))))))
-
-(defun kotct/user-fetch-config (username)
-  "Fetch USERNAME's personal config from GitHub, out of the
-repository USERNAME/.emacs."
-  (message "fetching config for %s" username)
-  (let ((default-directory "~/.emacs.d/lisp/user/users/")
-        (url (format "https://github.com/%s/.emacs.git" username)))
-    (kotct/run-git "clone" url username)))
-
-(defun kotct/user-update-config (&optional username)
-  "Update USERNAME's personal config git repository.
-If USERNAME is nil, prompt for a username."
-  (interactive)
-  (unless username
-    (setf username
-          (kotct/user-ask-username "Update config for: " 'require-match)))
-  (let ((default-directory (format "~/.emacs.d/lisp/user/users/%s" username)))
-    (kotct/run-git "pull" "origin" "master"))
-  (if (eq username kotct/user-current-username)
-      ;; reload the config
-      (kotct/user-switch-username username))
-  (message "@%s's config updated!" username))
 
 (defun kotct/user-get-default-username ()
   "Look up the default username set on this machine."


### PR DESCRIPTION
Currently we only support updating user configs, and the user isn't capable of viewing the diff.

This patch allows for the user to update both user configs and kotct/dot. 
Furthermore it allows for the user to view the difference between `HEAD` and `master` before deciding whether to pull the update. 

Note: this requires a repository that doesn't require authentication to run `git fetch origin master` or `git pull origin master`.