### PR TITLE
Update Emacs versions used for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 cache: apt
 
 env:
-  - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: apt
 
 env:
   - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-26.2-travis
 
 before_install:
   - git clone https://github.com/rejeep/evm.git ~/.evm


### PR DESCRIPTION
Some dependencies (e.g. Magit?) have now a hard requirement on Emacs 25, and since we don't pin versions of our dependencies there is no recourse besides to simply drop support for those now broken versions.

[The README](https://github.com/kotct/dot/blob/61b9eb5/README.md#installation) says:

>If your system is running an older version of a dependency software, (i.e. **Emacs < 25.1**, Ruby < 2.4) please do your best to update to the latest version directly available from your package manager. If an issue is not reproducible on our system, we cannot fix it.

This PR drops Emacs 24.5 from the build matrix and replaces 26.1 with 26.2. I'd be happy to add more minor versions, but I think the current process is to test latest minor versions only.