### PR TITLE
travis: Stop Slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,3 @@ before_script:
 script:
   - emacs --script .emacs.d/test/lisp/run-tests.el
   - emacs --script .emacs.d/init.el
-
-notifications:
-  slack:
-    secure: Pu2AagcBjx2iBPwsIJ3oNdB5koGfqSP12Mat9KYajxtIwbyzgGsToiyma3+s+Yl02+IRZdGonZaKH/c2RGNF05PK4PAoNfkhYafiog4hKD5ZusIi1xVr0zWOREZVsqpAeu0cxs/b+p7Va66+CRukGYxTGs0LjfEXoJ3KRJYwziSVDYVEoujGHFTPKlyNZNU0fSW+pioVneiVy+hpVvfdzqby9WJG9nK/607xceJ+HVdntXABnUBDk6/1KVqbH36U2Xlw2hlRebGWIowqg/S6yOqn+NxvrM5FNb7LHWxx/mLM3o5Ml1pm9mcDS0M+sPOquLlW/0NPfiV3cz485W6aoSo37z9eassQ4DKQsEjiL4AfGXH4Wgu3BASnWTMkSXfGwW09rKSu1PCyozp76htkiMWp2tJQo/GUAey7PYTSEHhFWBhBL2UaJ3WY4H/1SdaVqHwnBNXU6YEMIJn0S7F31MmQUmSIcVMbqP9XojWl9DHDKP9o4S5CCshYlKR3XzdSeOzyQKb2PKr5NAtU2lYVMfL4XYEsz+sWO1yOCUB+U0yVXdk9kInGHY5AAwIJ6v/ODSDGW67SlXMAJcrkW2nlX8I9JZ+aR4vKo47j+MCPsPMBaPoHyGquVe9++iq67Kdxl18azrQ6fVbjNda3LRTZVH9ekWRf9eMsVBbSeyORUx8=
-    on_success: change


### PR DESCRIPTION
We don't have a Slack instance anymore, so it's best to stop trying to send those notifications out.
