### PR TITLE
Add LSP support

### DIFF
--- a/.emacs.d/.gitignore
+++ b/.emacs.d/.gitignore
@@ -18,6 +18,7 @@ session.*
 recentf
 custom.el
 eshell/
+.lsp-*
 
 # packages
 elpa/

--- a/.emacs.d/lisp/code/languages/rust.el
+++ b/.emacs.d/lisp/code/languages/rust.el
@@ -16,10 +16,4 @@
 ;; Don't indent `where' clauses in Rust.
 (setf rust-indent-where-clause nil)
 
-;; Enable LSP (to talk to RLS) on all rust-mode buffers
-;;
-;; NOTE This could get quite annoying if you're not aiming to use RLS
-(require 'lsp-mode)
-(add-hook #'rust-mode-hook #'lsp)
-
 (provide 'rust)

--- a/.emacs.d/lisp/code/languages/rust.el
+++ b/.emacs.d/lisp/code/languages/rust.el
@@ -16,4 +16,10 @@
 ;; Don't indent `where' clauses in Rust.
 (setf rust-indent-where-clause nil)
 
+;; Enable LSP (to talk to RLS) on all rust-mode buffers
+;;
+;; NOTE This could get quite annoying if you're not aiming to use RLS
+(require 'lsp-mode)
+(add-hook #'rust-mode-hook #'lsp)
+
 (provide 'rust)

--- a/.emacs.d/lisp/package/dependencies.el
+++ b/.emacs.d/lisp/package/dependencies.el
@@ -28,6 +28,8 @@
     fish-mode ;; for editing fish shell configuration files
     go-mode ;; for editing go code
     go-autocomplete ;; AC support for go
+    lsp-mode ;; for editing with any language that has a language server
+    lsp-ui ;; to support viewing lsp-bound files with flycheck and code lenses
 
     ;; THEMES
     solarized-theme)

--- a/.emacs.d/lisp/package/dependencies.el
+++ b/.emacs.d/lisp/package/dependencies.el
@@ -29,7 +29,6 @@
     go-mode ;; for editing go code
     go-autocomplete ;; AC support for go
     lsp-mode ;; for editing with any language that has a language server
-    lsp-ui ;; to support viewing lsp-bound files with flycheck and code lenses
 
     ;; THEMES
     solarized-theme)


### PR DESCRIPTION
This PR adds `lsp-mode` (https://github.com/emacs-lsp/lsp-mode) to the project, and demonstrates adding support for LSP in a specific language.

`lsp-mode` is a big project but seems like a _very_ solid companion for this project. In particular:

> `lsp-mode` aims to provide IDE-like experience by providing optional integration with the most popular Emacs packages like `company`, `flycheck` and `projectile`.

How do they do it? A "language server" is implemented for each language, and the "language server protocol" (JSON+RPC-based) is implemented by these servers, allowing for tasks common to all languages (code completion, hover things, jump-to-def, workspacing, and diagnostics) to be implemented once by those who know the language well.

This means that rather than write bindings for each editor for each language, (with M editors and N languages, that's M*N implementations) instead one ostensibly only needs to write one language server for each language and one client for each editor, reducing the number of implementations to M+N.

In reality, it's a bit closer to M*N+kN, where k is a small constant, as there is a bit of variability in how language servers are implemented, found, and selected between languages, but this is all just wiring effort and thus much easier to support in the long-run.

---

Some questions before I open this for merging:

- [x] Would we want to take a bold step like turning on `lsp-mode` for `prog-mode-hook` instead of just selectively enabling for certain languages? In this way, `lsp-mode` becomes the bottleneck for support, and we don't have to maintain any code. LSPs are also only used when they are found.
- [x] Do we want to be opinionated about adopting `flymake` vs `company-*`? It's been a while since I've taken a look at the differences in opinion about those. We could leave those up to the user and just use the defaults that `lsp-mode` selects, if that's an okay compromise.