### PR TITLE
travis: Fix CI Errors, Upgrade Emacs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 cache: apt
 
 env:
-  - EVM_EMACS=emacs-25.3-travis-linux-xenial
+  - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.3-travis-linux-xenial
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 cache: apt
 
 env:
-  - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-26.3-travis
+  - EVM_EMACS=emacs-25.3-travis-linux-xenial
+  - EVM_EMACS=emacs-26.3-travis-linux-xenial
 
 before_install:
   - git clone https://github.com/rejeep/evm.git ~/.evm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: apt
 
 env:
   - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-26.2-travis
+  - EVM_EMACS=emacs-26.3-travis
 
 before_install:
   - git clone https://github.com/rejeep/evm.git ~/.evm


### PR DESCRIPTION
Emacs 26.3 was released on 2019-08-28, so probably a good idea to test against it now.