### PR TITLE
allow changing font size while viewing read-only files

### DIFF
--- a/.emacs.d/lisp/visual/text-visuals.el
+++ b/.emacs.d/lisp/visual/text-visuals.el
@@ -51,9 +51,9 @@
                      (/ (face-attribute 'default :height) 10.0))))
     (set-face-attribute 'default nil :height (floor (* 10.0 new-size)))))
 
-(defun kotct/font-upscale-height () (interactive "*") (kotct/font-rescale-height +1.0))
-(defun kotct/font-downscale-height () (interactive "*") (kotct/font-rescale-height -1.0))
-(defun kotct/font-reset-height () (interactive "*") (kotct/font-set-height kotct/font-default-height))
+(defun kotct/font-upscale-height () (interactive) (kotct/font-rescale-height +1.0))
+(defun kotct/font-downscale-height () (interactive) (kotct/font-rescale-height -1.0))
+(defun kotct/font-reset-height () (interactive) (kotct/font-set-height kotct/font-default-height))
 
 (global-unset-key (kbd "C-x C-+"))
 (global-unset-key (kbd "C-x C-="))


### PR DESCRIPTION
Honestly not a fan of how we've set up font-size stuff in general, especially
since it keeps you from changing the font size for a specific buffer. But this
bug has been really pissing me off lately.
