### PR TITLE
startup: Print GC information

### DIFF
--- a/.emacs.d/lisp/visual/startup-c.el
+++ b/.emacs.d/lisp/visual/startup-c.el
@@ -13,7 +13,7 @@
           (lambda ()
             (if (equal initial-scratch-message *inital-scratch-message-value*)
                 (setq initial-scratch-message
-                      (concat ";; init: " (emacs-init-time) (format-time-string " @ %F %T") " (gc: " (format "%d" gcs-done) "x, " (format "%f" gc-elapsed) "s)"
+                      (concat ";; init: " (emacs-init-time) (format-time-string " @ %F %T") " (gc: " (format "%d" gcs-done) "x, " (format "%.3f" gc-elapsed) "s)"
                               "\n;; " (user-login-name) "@" (system-name) " loaded config for " kotct/user-current-username
                               "\n;; need help? try <C-h ?>"
                               "\n;; scratch away\n\n")))))

--- a/.emacs.d/lisp/visual/startup-c.el
+++ b/.emacs.d/lisp/visual/startup-c.el
@@ -13,7 +13,7 @@
           (lambda ()
             (if (equal initial-scratch-message *inital-scratch-message-value*)
                 (setq initial-scratch-message
-                      (concat ";; init: " (emacs-init-time) (format-time-string " @ %F %T")
+                      (concat ";; init: " (emacs-init-time) (format-time-string " @ %F %T") " with " (format "%d" gcs-done) " GCs"
                               "\n;; " (user-login-name) "@" (system-name) " loaded config for " kotct/user-current-username
                               "\n;; need help? try <C-h ?>"
                               "\n;; scratch away\n\n")))))

--- a/.emacs.d/lisp/visual/startup-c.el
+++ b/.emacs.d/lisp/visual/startup-c.el
@@ -13,7 +13,7 @@
           (lambda ()
             (if (equal initial-scratch-message *inital-scratch-message-value*)
                 (setq initial-scratch-message
-                      (concat ";; init: " (emacs-init-time) (format-time-string " @ %F %T") " with " (format "%d" gcs-done) " GCs accounting for " (format "%f" gc-elapsed) "s"
+                      (concat ";; init: " (emacs-init-time) (format-time-string " @ %F %T") " (gc: " (format "%d" gcs-done) "x, " (format "%f" gc-elapsed) "s)"
                               "\n;; " (user-login-name) "@" (system-name) " loaded config for " kotct/user-current-username
                               "\n;; need help? try <C-h ?>"
                               "\n;; scratch away\n\n")))))

--- a/.emacs.d/lisp/visual/startup-c.el
+++ b/.emacs.d/lisp/visual/startup-c.el
@@ -13,7 +13,7 @@
           (lambda ()
             (if (equal initial-scratch-message *inital-scratch-message-value*)
                 (setq initial-scratch-message
-                      (concat ";; init: " (emacs-init-time) (format-time-string " @ %F %T") " with " (format "%d" gcs-done) " GCs"
+                      (concat ";; init: " (emacs-init-time) (format-time-string " @ %F %T") " with " (format "%d" gcs-done) " GCs accounting for " (format "%f" gc-elapsed) "s"
                               "\n;; " (user-login-name) "@" (system-name) " loaded config for " kotct/user-current-username
                               "\n;; need help? try <C-h ?>"
                               "\n;; scratch away\n\n")))))


### PR DESCRIPTION
Because we (currently) use an interesting hodgepodge of sync and async loading during startup, I think it might be useful to convey to the user some information about how much garbage collection occurred during startup. Loading things (processing functions, strings, etc., and just general startup work) will necessarily produce garbage to be swept, and so it might be helpful to know just how much is happening during our init sweep.

This PR adds a small printout of the _number_ of GC sweeps and the _amount of time spent doing GC_ during startup.  The `initial-scratch-message` is populated by the `after-init-hook` which means the readout should capture all the GC data.

```elisp
;; init: 3.6 seconds @ 2020-07-24 12:47:05 (gc: 42x, 0.900s)
;; kristofer@maero.local loaded config for rye
;; need help? try <C-h ?>
;; scratch away
```

I've had success in reducing the number of GCs by bumping up `gc-cons-threshold` and fiddling with `gc-cons-percentage`, but it's nice to be able to get a grasp on where we're at right now.

One possible change I could make is to gate this behind a variable. Note that both `gcs-done` and `gc-elapsed` are variables that are populated by Emacs' C code in `alloc.c`, so this doesn't add much overhead besides a few more strings in the concat call and the two calls to `format`.