### PR TITLE
fix #141 remove depricated cl, replace w/ cl-lib

### DIFF
--- a/.emacs.d/lisp/behavior/text.el
+++ b/.emacs.d/lisp/behavior/text.el
@@ -4,7 +4,7 @@
 ;;; C-+: undo C-=
 ;;; C-M-w: copy sexp to kill ring, appending if called repeatedly
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;; avy jump mode
 (global-set-key (kbd "C-c SPC") #'avy-goto-word-1)
@@ -28,7 +28,7 @@
   0
   "Number of commands since last `kotct/sexp-copy-as-kill'.")
 
-(add-hook 'pre-command-hook (lambda () (incf kotct/sexp-copy-count)))
+(add-hook 'pre-command-hook (lambda () (cl-incf kotct/sexp-copy-count)))
 
 (defun kotct/sexp-copy-as-kill (arg)
   "Save next sexp as if killed, but don't kill it, appending if called repeatedly."

--- a/.emacs.d/lisp/file/recentf-c.el
+++ b/.emacs.d/lisp/file/recentf-c.el
@@ -3,7 +3,6 @@
 ;; `require' these because we need some of recentf's things now prior
 ;; to the autoload at the end of the file.
 (require 'recentf)
-(require 'cl)
 
 ;; Keep only the last 200 saved items.
 (setf recentf-max-saved-items 200)

--- a/.emacs.d/lisp/package/packup.el
+++ b/.emacs.d/lisp/package/packup.el
@@ -6,7 +6,7 @@
 
 (require 'dependencies)
 (require 'package)
-(require 'cl)
+(require 'cl-lib)
 
 (package-initialize)
 
@@ -27,7 +27,7 @@ from the most-preferred repository."
                                        (car (cl-member pinned-archive (cdr pkg)
                                                        :key #'package-desc-archive
                                                        :test #'string=)))))
-                          (dolist (archive kotct/package-ordered-archives)
+                          (cl-dolist (archive kotct/package-ordered-archives)
                             (when (not desc)
                               ;; no match yet, keep looking
                               (setf desc (car (cl-member archive (cdr pkg)
@@ -52,7 +52,7 @@ Does not automatically refresh the package list."
                      (car (cl-member pinned-archive versions
                                      :key #'package-desc-archive
                                      :test #'string=)))))
-        (dolist (archive kotct/package-ordered-archives)
+        (cl-dolist (archive kotct/package-ordered-archives)
           (when (not found-desc)
             ;; no match yet, keep looking
             (setf found-desc (car (cl-member archive versions
@@ -218,7 +218,7 @@ contents of the buffer."
     (kill-region (point-min) (point-max)))
   (package-refresh-contents)
   (let ((install-list nil))
-    (dolist (package kotct/dependency-list)
+    (cl-dolist (package kotct/dependency-list)
       (when (not (kotct/package-up-to-date-p package))
         (apply #'kotct/packup-insert-package-row (list package (package-desc-version (kotct/package-latest-available package))))))))
 
@@ -293,7 +293,7 @@ If AUTO-UPDATE is non-nil, out-of-date/uninstalled packages will be updated."
   ;; install-list is a list of cons cells
   ;; the car of each is a package-desc, the cdr is the currently installed package-desc
   (let (install-list)
-    (dolist (package kotct/dependency-list)
+    (cl-dolist (package kotct/dependency-list)
 
       (if (or (not (package-installed-p package))
               (and update (not (kotct/package-up-to-date-p package))))
@@ -305,7 +305,7 @@ If AUTO-UPDATE is non-nil, out-of-date/uninstalled packages will be updated."
 
         (progn (with-output-to-temp-buffer "*packup: packages to upgrade*"
                  (princ "Packages to be installed:")
-                 (dolist (package-cons install-list)
+                 (cl-dolist (package-cons install-list)
                    (message (symbol-name (package-desc-name (car package-cons))))
                    (terpri)
                    (princ (symbol-name (package-desc-name (car package-cons))))
@@ -327,7 +327,7 @@ If AUTO-UPDATE is non-nil, out-of-date/uninstalled packages will be updated."
                           (kill-buffer "*packup: packages to upgrade*")
                           (message "Dependency installation completed."))
                  (let ((manual-install-list nil))
-                   (dolist (package-cons install-list)
+                   (cl-dolist (package-cons install-list)
                      (if (y-or-n-p (format "Package %s is %s. Install %s? "
                                            (package-desc-name (car package-cons))
                                            (if (cdr package-cons)

--- a/.emacs.d/lisp/package/verification.el
+++ b/.emacs.d/lisp/package/verification.el
@@ -1,4 +1,4 @@
-(require 'cl)
+(require 'cl-lib)
 
 ;; check to make sure all dependencies are installed before continuing
 (defun kotct/check-dependency-list (&optional frame)
@@ -9,7 +9,7 @@ FRAME is used to determine whether or not we are running headless
 (e.g., as a result of `emacs --daemon`). If we are, throw 'daemon-mode.
 It is the caller's responsibility to catch this and handle it properly.
 Typically this happens in init.el."
-  (if (not (every #'package-installed-p kotct/dependency-list))
+  (if (not (cl-every #'package-installed-p kotct/dependency-list))
       (if (string= (terminal-name (frame-terminal frame)) "initial_terminal")
           (throw 'daemon-mode 'daemon-mode)
         (y-or-n-p "You don't seem to have all necessary packages installed. Install them?\n(This configuration will probably not work if you don't.)")


### PR DESCRIPTION
This commit removes the deprecated references to `cl` from our configuration and replaces them with new calls to function in `cl-lib`. 

This should work modulo potential differences between the old and new `cl-member` functions. 