### PR TITLE
require rust-mode; closes #147

### DIFF
--- a/.emacs.d/lisp/code/languages/rust.el
+++ b/.emacs.d/lisp/code/languages/rust.el
@@ -1,4 +1,5 @@
 (require 'indentation)
+(require 'rust-mode)
 
 ;; Set `rust-indent-offset' to the `global-tab-width' value.
 (kotct/setq-default-tab rust-indent-offset)


### PR DESCRIPTION
Require `rust-mode` in `rust.el`.

Closes #147 