### PR TITLE
change `languages` defvar to `kotct/languages`

### DIFF
--- a/.emacs.d/lisp/code/languages/language-hub.el
+++ b/.emacs.d/lisp/code/languages/language-hub.el
@@ -1,4 +1,4 @@
-(defvar languages
+(defvar kotct/languages
   '(c
     elisp
     elixir
@@ -13,7 +13,7 @@
   "A list of packages configured by the language-hub.")
 
 (let ((to-compile ()))
-  (dolist (feature languages)
+  (dolist (feature kotct/languages)
     (setf to-compile
           (cons (concat (file-name-directory load-file-name) (symbol-name feature) ".el") to-compile))
     (require feature))


### PR DESCRIPTION
this breaks lsp-mode here
https://github.com/emacs-lsp/lsp-mode/blob/8105218b383c1a8a209a5f3348956a0b51446d43/lsp-mode.el#L4998
`languages` refers to the defvar instead of the local var for some reason

in retrospect, naming a global var `languages` probably wasn't the smartest