### PR TITLE
replace missing packages

### DIFF
--- a/.emacs.d/lisp/package/dependencies.el
+++ b/.emacs.d/lisp/package/dependencies.el
@@ -22,9 +22,7 @@
     yaml-mode ;; for editing YAML files
     buttercup ;; for tests
     smartparens ;; for dealing with paired control flow symbols
-    gitignore-mode ;; for editing .gitignore files
-    gitattributes-mode ;; for editing .gitattributes files
-    gitconfig-mode ;; for editing .git/config files
+    git-modes ;; for editing .gitignore, .gitattributes, and .git/config files
     fish-mode ;; for editing fish shell configuration files
     go-mode ;; for editing go code
     go-autocomplete ;; AC support for go


### PR DESCRIPTION
This causes a nasty crash in packup, including during first initialization.

We should also fix the failure mode but that's more difficult.