### PR TITLE
avoid calling deprecated global-linum-mode

### DIFF
--- a/.emacs.d/lisp/visual/line-numbers-c.el
+++ b/.emacs.d/lisp/visual/line-numbers-c.el
@@ -28,7 +28,7 @@ This mode was added in Emacs 26.1 and is recommended over `linum-mode' because
 it generally works better."
   (progn
     ;; inhibit global-linum-mode
-    (global-linum-mode -1)
+    (if (fboundp #'global-linum-mode) (global-linum-mode -1))
     (global-display-line-numbers-mode 1)
 
     ;; add some hooks to turn off display-line-numbers mode


### PR DESCRIPTION
Emacs 29 finally removed linum-mode, so now global-linum-mode is not defined. Since we were only calling it here to disable it, just check that it's bound first. If not bound, just skip completely.