### PR TITLE
fix editorconfig on emacs 30

### DIFF
--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -21,7 +21,7 @@ and is ignored."
 
 Debug warning is suppressed if SUPPRESS is non-nil."
 
-  (if (not suppress)
+  (if (and (not suppress) (fboundp 'editorconfig-exec-path))
       (if (not (executable-find editorconfig-exec-path))
           (message "EditorConfig C Core not found in `editorconfig-exec-path'."))))
 


### PR DESCRIPTION
Emacs 30 ships with a totally different version of editorconfig-mode that appears to be derived from the original package but with all non-copyright-assigned code removed. See
https://github.com/emacs-mirror/emacs/commit/f563f0f961068e5732b9770908ebfd915a93fe12

Which is kind of insane, but whatever. This PR fixes a crash on Emacs 30 that results from differences in the packages.