### PR TITLE
use boundp instead of fboundp

### DIFF
--- a/.emacs.d/lisp/code/editorconfig-c.el
+++ b/.emacs.d/lisp/code/editorconfig-c.el
@@ -21,7 +21,7 @@ and is ignored."
 
 Debug warning is suppressed if SUPPRESS is non-nil."
 
-  (if (and (not suppress) (fboundp 'editorconfig-exec-path))
+  (if (and (not suppress) (boundp 'editorconfig-exec-path))
       (if (not (executable-find editorconfig-exec-path))
           (message "EditorConfig C Core not found in `editorconfig-exec-path'."))))
 


### PR DESCRIPTION
Follow up to #153. `editoconfig-exec-path` is a variable, not a function, so this is what I actually wanted.